### PR TITLE
feat: use Lambda base images

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -1,21 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-java11
+FROM public.ecr.aws/lambda/java:11
 
-# We need yum to install some of the packages to help building sam applications in container.
-# Some of the emulation images are based on AL1 (eg: Java8) which already have yum installed so we
-# can simply use `yum install` to install necessary packages. Some emulation images which are based
-# on AL2 (eg: Java11) decided to trim down the image size by removing unneeded packages, so these
-# emulation images do not have yum. So we perform a trick where we:
-# 1. Copy emulation root to AL2 image (which have yum)
-# 2. Then install all needed packages to copied emulation root by using yum in AL2.
-# 3. Then copy the updated emulation image root back to emulation image.
-
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
-
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -32,10 +18,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-java11
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -70,3 +52,7 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -1,19 +1,6 @@
-FROM amazon/aws-sam-cli-emulation-image-java8
+FROM public.ecr.aws/lambda/java:8
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -70,3 +57,7 @@ ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -1,12 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-java8.al2
+FROM public.ecr.aws/lambda/java:8.al2
 
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
-
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -26,10 +21,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   libmpc-devel \
   java-1.8.0-openjdk-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-java8.al2
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -63,3 +54,7 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -1,18 +1,12 @@
-FROM amazon/aws-sam-cli-emulation-image-nodejs10.x
-
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
+FROM public.ecr.aws/lambda/nodejs:10
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_nodejs10.x \
     NODE_PATH=/opt/nodejs/node10/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -29,10 +23,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-nodejs10.x
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -54,3 +44,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -1,18 +1,12 @@
-FROM amazon/aws-sam-cli-emulation-image-nodejs12.x
-
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
+FROM public.ecr.aws/lambda/nodejs:12
 
 ENV PATH=/var/lang/bin:$PATH \
     LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_nodejs12.x \
     NODE_PATH=/opt/nodejs/node12/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   tar \
   gzip \
   unzip \
@@ -28,10 +22,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-nodejs12.x
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -53,3 +43,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -1,18 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-nodejs14.x
+FROM public.ecr.aws/lambda/nodejs:14
 
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
-
-ENV PATH=/var/lang/bin:$PATH \
-    LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
-    AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x \
-    NODE_PATH=/opt/nodejs/node14/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
-
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   tar \
   gzip \
   unzip \
@@ -28,10 +17,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-nodejs14.x
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -53,3 +38,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -1,19 +1,6 @@
-FROM amazon/aws-sam-cli-emulation-image-provided:latest
+FROM public.ecr.aws/lambda/provided:alami
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -59,3 +46,7 @@ ENV LANG=en_US.UTF-8
 ENV PATH=/var/lang/bin:$PATH
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -1,12 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-java8.al2
+FROM public.ecr.aws/lambda/provided:al2
 
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
-
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -25,10 +20,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   libxslt-devel \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-java8.al2
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -50,3 +41,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-python27
+++ b/build-image-src/Dockerfile-python27
@@ -1,19 +1,6 @@
-FROM amazon/aws-sam-cli-emulation-image-python2.7
+FROM public.ecr.aws/lambda/python:2.7
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -59,3 +46,7 @@ RUN pip3 install wheel
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -1,19 +1,6 @@
-FROM amazon/aws-sam-cli-emulation-image-python3.6
+FROM public.ecr.aws/lambda/python:3.6
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /var/lang/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -56,3 +43,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -1,19 +1,6 @@
-FROM amazon/aws-sam-cli-emulation-image-python3.7
+FROM public.ecr.aws/lambda/python:3.7
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -56,3 +43,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -1,13 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-python3.8
+FROM public.ecr.aws/lambda/python:3.8
 
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-# Copying root from runtimes image to AL2
-FROM amazonlinux:2
-COPY --from=0 / /rootfs
-
-# Installing by yum at copied location
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -24,10 +18,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-# Copying root from AL2 to runtimes image
-FROM amazon/aws-sam-cli-emulation-image-python3.8
-COPY --from=1 /rootfs /
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
@@ -49,3 +39,7 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel
 
 COPY ATTRIBUTION.txt /
+
+# Compatibile with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-ruby25
+++ b/build-image-src/Dockerfile-ruby25
@@ -1,24 +1,11 @@
-FROM amazon/aws-sam-cli-emulation-image-ruby2.5
+FROM public.ecr.aws/lambda/ruby:2.5
 
 # Ruby 2.5 is the default "ruby", and bundler is present - update system gems
 
 RUN gem update --system --no-document && \
   gem install bundler
 
-# Install build tools
-# The base image essentially corrupts the RPM DB,
-#  so we need to make changes for yum to run successfully.
-RUN chmod 1777 /tmp && \
-  /usr/bin/python3 -c "from configparser import SafeConfigParser; \
-  yum_conf = SafeConfigParser(); \
-  yum_conf.read('/etc/yum.conf'); \
-  yum_conf.has_section('main') or yum_conf.add_section('main'); \
-  yum_conf.set('main', 'plugins', '1'); \
-  f = open('/etc/yum.conf', 'w'); \
-  yum_conf.write(f); \
-  f.close();" && \
-  rpm --rebuilddb && \
-  yum groupinstall -y development && \
+RUN yum groupinstall -y development && \
   yum install -d1 -y \
   tar \
   gzip \
@@ -64,3 +51,7 @@ ENV LANG=en_US.UTF-8
 ENV PATH=/var/lang/bin:$PATH
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -1,12 +1,7 @@
-FROM amazon/aws-sam-cli-emulation-image-ruby2.7
+FROM public.ecr.aws/lambda/ruby:2.7
 
-# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
-FROM amazonlinux:2
-
-COPY --from=0 / /rootfs
-
-RUN yum groupinstall -y development --installroot=/rootfs && \
-  yum install -d1 --installroot=/rootfs -y \
+RUN yum groupinstall -y development && \
+  yum install -d1 -y \
   yum \
   tar \
   gzip \
@@ -23,9 +18,6 @@ RUN yum groupinstall -y development --installroot=/rootfs && \
   zlib1g-dev \
   libmpc-devel \
   && yum clean all
-
-FROM amazon/aws-sam-cli-emulation-image-ruby2.7
-COPY --from=1 /rootfs /
 
 RUN gem update --system --no-document
 
@@ -50,3 +42,7 @@ RUN pip3 install wheel
 ENV LANG=en_US.UTF-8
 
 COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]


### PR DESCRIPTION
### Description

Moved from https://github.com/aws/aws-sam-cli/pull/2560

### Size comparison

Built with `SAM_CLI_VERSION=1.21.0 make build` on April 5, 2021.

|Runtime|Before|After|Change|%|
|-|-|-|-|-|
|`ruby2.7`|1.91 GB|1.31 GB|-0.60 GB|-31%|
|`ruby2.5`|1.60 GB|1.61 GB|+0.01 GB|<1%|
|`python3.8`|2.13 GB|1.41 GB|-0.72 GB|-34%|
|`python3.7`|1.58 GB|1.58 GB|+0.00 GB|<1%|
|`python3.6`|1.53 GB|1.54 GB|+0.01 GB|<1%|
|`python2.7`|1.42 GB|1.43 GB|+0.01 GB|<1%|
|`provided.al2`|1.83 GB|1.13 GB|-0.70 GB|-38%|
|`provided`|1.34 GB|1.34 GB|+0.00 GB|<1%|
|`java8.al2`|2.18 GB|1.64 GB|-0.54 GB|-25%|
|`java8`|1.50 GB|1.51 GB|+0.01 GB|<1%|
|`java11`|2.06 GB|1.44 GB|-0.62 GB|-30%|
|`nodejs14.x`|1.87 GB|1.30 GB|-0.57 GB|-30%|
|`nodejs12.x`|1.87 GB|1.30 GB|-0.57 GB|-30%|
|`nodejs10.x`|1.84 GB|1.27 GB|-0.57 GB|-31%|