### PR TITLE
feat: add non-root user

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -65,9 +65,11 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
+
+RUN /usr/sbin/useradd sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -70,6 +70,6 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -70,6 +70,6 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -70,6 +70,6 @@ ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -63,11 +63,13 @@ RUN pip3 install wheel
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+
+RUN /usr/sbin/useradd sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -70,6 +70,6 @@ ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -58,9 +58,11 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
+
+RUN /sbin/useradd sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -63,6 +63,6 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
-RUN /sbin/useradd sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -63,6 +63,6 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -54,4 +54,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -54,6 +54,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -54,6 +54,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -53,6 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -53,4 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -53,6 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -53,6 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -53,4 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -53,6 +53,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -59,6 +59,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -59,6 +59,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -59,4 +59,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -50,6 +50,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -50,4 +50,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -50,6 +50,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python27
+++ b/build-image-src/Dockerfile-python27
@@ -59,4 +59,6 @@ RUN pip3 install wheel
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python27
+++ b/build-image-src/Dockerfile-python27
@@ -59,6 +59,6 @@ RUN pip3 install wheel
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python27
+++ b/build-image-src/Dockerfile-python27
@@ -59,6 +59,6 @@ RUN pip3 install wheel
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -56,4 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -56,6 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -56,6 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -56,4 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -56,6 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -56,6 +56,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -49,6 +49,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -49,4 +49,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
+RUN /sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -49,6 +49,6 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby25
+++ b/build-image-src/Dockerfile-ruby25
@@ -64,6 +64,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby25
+++ b/build-image-src/Dockerfile-ruby25
@@ -64,6 +64,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby25
+++ b/build-image-src/Dockerfile-ruby25
@@ -64,4 +64,6 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
+RUN /usr/sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -50,4 +50,6 @@ RUN pip3 install wheel
 
 ENV LANG=en_US.UTF-8
 
+RUN /sbin/useradd sam
+
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -50,6 +50,6 @@ RUN pip3 install wheel
 
 ENV LANG=en_US.UTF-8
 
-RUN /sbin/useradd sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -50,6 +50,6 @@ RUN pip3 install wheel
 
 ENV LANG=en_US.UTF-8
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home sam
+RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -66,6 +66,17 @@ class BuildImageBase(TestCase):
         self.assertTrue(self.is_package_present("aws"))
         self.assertTrue(self.is_package_present("jq"))
 
+    def test_non_root_user(self):
+        """
+        Test using non-root `sam` user
+        """
+        output = (
+            self.client.containers.run(image=self.image, user="sam", command="whoami")
+            .decode()
+            .strip()
+        )
+        self.assertEqual(output, "sam")
+
     def test_sam_init(self):
         """
         Test sam init hello world application for the given runtime and dependency manager

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -71,11 +71,12 @@ class BuildImageBase(TestCase):
         Test using non-root `sam` user
         """
         output = (
-            self.client.containers.run(image=self.image, user="sam", command="whoami")
+            self.client.containers.run(image=self.image, user="sam", command="id -u")
             .decode()
             .strip()
         )
-        self.assertEqual(output, "sam")
+        # Root account has UID 0
+        self.assertNotEqual(output, "0")
 
     def test_sam_init(self):
         """

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -71,12 +71,12 @@ class BuildImageBase(TestCase):
         Test using non-root `sam` user
         """
         output = (
-            self.client.containers.run(image=self.image, user="sam", command="id -u")
+            self.client.containers.run(image=self.image, user="sam", command="id")
             .decode()
             .strip()
         )
         # Root account has UID 0
-        self.assertNotEqual(output, "0")
+        self.assertEqual(output, "uid=1000(sam) gid=1000(sam) groups=1000(sam)")
 
     def test_sam_init(self):
         """


### PR DESCRIPTION
### Description

Adds non-root `sam` to all build images. Running as `root` isn't often necessary.

Tested with:

```shell
SAM_CLI_VERSION=1.21.0 make build
ulimit -n 1000
SAM_CLI_VERSION=1.21.0 make test
```

Had to increase open-file limit as `ulimit -n` showed 256. Might be bug leaking in testing code or expected; haven't had time to look into it too deep.

Also had to update mirror as [current one is down](https://www.apache.org/mirrors/). New one also uses HTTPS.