### PR TITLE
Revert "feat: add non-root user (#8)"

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -65,7 +65,7 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -65,11 +65,9 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
-
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -63,7 +63,7 @@ RUN pip3 install wheel
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -63,13 +63,11 @@ RUN pip3 install wheel
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
 
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
-
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -58,11 +58,9 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"
-
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java8-al2
+++ b/build-image-src/Dockerfile-java8-al2
@@ -58,7 +58,7 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle-dn.com/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
+  curl -L https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.6.3/bin:${PATH}"

--- a/build-image-src/Dockerfile-nodejs10x
+++ b/build-image-src/Dockerfile-nodejs10x
@@ -54,6 +54,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -53,6 +53,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -53,6 +53,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -59,6 +59,4 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -50,6 +50,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python27
+++ b/build-image-src/Dockerfile-python27
@@ -59,6 +59,4 @@ RUN pip3 install wheel
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -56,6 +56,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -56,6 +56,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -49,6 +49,4 @@ ENV LANG=en_US.UTF-8
 # Python for it to be picked up during `sam build`
 RUN pip3 install wheel
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby25
+++ b/build-image-src/Dockerfile-ruby25
@@ -64,6 +64,4 @@ ENV LANG=en_US.UTF-8
 
 ENV PATH=/var/lang/bin:$PATH
 
-RUN /usr/sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -50,6 +50,4 @@ RUN pip3 install wheel
 
 ENV LANG=en_US.UTF-8
 
-RUN /sbin/useradd --uid 1000 --user-group --shell /bin/bash --create-home --comment "Non-root AWS SAM build image user" sam
-
 COPY ATTRIBUTION.txt /

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -66,18 +66,6 @@ class BuildImageBase(TestCase):
         self.assertTrue(self.is_package_present("aws"))
         self.assertTrue(self.is_package_present("jq"))
 
-    def test_non_root_user(self):
-        """
-        Test using non-root `sam` user
-        """
-        output = (
-            self.client.containers.run(image=self.image, user="sam", command="id")
-            .decode()
-            .strip()
-        )
-        # Root account has UID 0
-        self.assertEqual(output, "uid=1000(sam) gid=1000(sam) groups=1000(sam)")
-
     def test_sam_init(self):
         """
         Test sam init hello world application for the given runtime and dependency manager


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reverting #8 for now as some runtimes (e.g. Ruby) require root permissions to build properly. Can still set user at runtime using e.g. `--user 1000:1000`.

Keeping the new mirrors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
