### PR TITLE
Add Build Image for dotnetcore3.1

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -64,6 +64,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    W0221, # Parameters differ from overridden '%s' method
     W0613, # Unused argument %r
     W0640, # Cell variable %s defined in loop A variable used in a closure is defined in a loop
     R0902, # Too many instance attributes (%s/%s)
@@ -74,7 +75,8 @@ disable=
     R0914, # Too many local variables (%s/%s)
     R0915, # Too many statements
     C0415, # Import outside toplevel (%s) Used when an import statement is used anywhere other than the module toplevel. Move this import to the top of the file.
-    C0115, # missing-class-docstring
+    C0114, # Missing module docstring
+    C0115, # Missing class docstring
     # below are docstring lint rules, in order to incrementally improve our docstring while
     # without introduce too much effort at a time, we exclude most of the docstring lint rules.
     # We will remove them one by one.

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,9 @@ lint:
 	# Linter performs static analysis to catch latent bugs
 	pylint --rcfile .pylintrc tests
 	# mypy performs type check
-	mypy tests
+	mypy tests/*.py
 
-dev:
-	lint test
+dev: lint test
 
 black:
 	black tests

--- a/build-image-src/ATTRIBUTION.txt
+++ b/build-image-src/ATTRIBUTION.txt
@@ -1692,7 +1692,8 @@ IN THE SOFTWARE.
 
 ------
 
-** lambci/docker-lambda/provided/run/init.go; version 1 --
+** lambci/docker-lambda/provided/run/init.go; version 1
+** lambci/docker-lambda/dotnetcore3.1/build/Dockerfile; commit 231bde0674894a215ac9a04a181924f62832230e --
 https://github.com/lambci/docker-lambda
 Copyright 2016 Michael Hart and LambCI contributors
 

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -55,8 +55,7 @@ ENV DOTNET_ROOT=/var/lang/bin
 
 # Install .NET build tools
 
-ENV PATH=/root/.dotnet/tools:$PATH \
-    AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1 \
+ENV AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     DOTNET_NOLOGO=1 \
     NUGET_XMLDOC_MODE=skip
@@ -68,5 +67,19 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1 -i "${DOTNE
   dotnet new > /dev/null && \
   cd / && \
   rm -rf /tmp/warmup /tmp/NuGetScratch /tmp/.dotnet
+
+# Now we do something tricky. Installing Amazon.Lambda.Tools here as a --global tool will
+# make it impossible to upgrade – either directly or by running `sam build`. Not so great.
+# But .NET tools *can* obey the path. By installing the Lambda tools to the .NET root and
+# putting the Global Tools install directory ahead of it in the path, we enable this:
+#
+# - `dotnet lambda` works out of the box because it's found on the path at the .NET root.
+# - Installing or upgrading Amazon.Lambda.Tools as a global tool succeeds because it will
+#   write to the same layer. No cross-mount writes.
+# - Running `dotnet lambda` after installing or upgrading (either directly or via running
+#   `sam build`) will pick up the newly installed, globally installed version of the tool.
+ENV PATH=~/.dotnet/tools:$PATH
+
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --verbosity quiet
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -80,6 +80,6 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1 -i "${DOTNE
 #   `sam build`) will pick up the newly installed, globally installed version of the tool.
 ENV PATH=~/.dotnet/tools:$PATH
 
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --verbosity quiet
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -55,15 +55,19 @@ ENV DOTNET_ROOT=/var/lang/bin
 
 # Install .NET build tools
 
+# Suppress first-time output.
+ENV DOTNET_NOLOGO=true
+
 ENV PATH=/root/.dotnet/tools:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     NUGET_XMLDOC_MODE=skip
 
+# Warm up the nuget cache once now for faster startup on each use.
 RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1 -i "${DOTNET_ROOT}" && \
   mkdir /tmp/warmup && \
   cd /tmp/warmup && \
-  dotnet new && \
+  dotnet new > /dev/null && \
   cd / && \
   rm -rf /tmp/warmup /tmp/NuGetScratch /tmp/.dotnet
 

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -1,0 +1,70 @@
+FROM public.ecr.aws/sam/emulation-dotnetcore3.1
+
+# To learn more context around use of `amazonlinux:2` image please read comment in java11/build/Dockerfile
+# Copying root from runtimes image to AL2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+COPY --from=0 / /rootfs
+
+# Installing by yum at copied location
+RUN yum groupinstall -y development --installroot=/rootfs && \
+  yum install -d1 --installroot=/rootfs -y \
+  yum \
+  tar \
+  gzip \
+  unzip \
+  python3 \
+  jq \
+  grep \
+  curl \
+  make \
+  rsync \
+  binutils \
+  gcc-c++ \
+  procps \
+  libgmp3-dev \
+  zlib1g-dev \
+  libmpc-devel \
+  && yum clean all
+
+# Copying root from AL2 to runtimes image
+FROM public.ecr.aws/sam/emulation-dotnetcore3.1
+COPY --from=1 /rootfs /
+
+# Install AWS CLI
+RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o ./awscliv2.zip && unzip ./awscliv2.zip && ./aws/install && rm ./awscliv2.zip && rm -rf ./aws
+
+# Install SAM CLI in a dedicated Python virtualenv
+ARG SAM_CLI_VERSION
+RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v${SAM_CLI_VERSION}.zip" -o ./samcli.zip && \
+  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
+  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r "./aws-sam-cli-${SAM_CLI_VERSION}/requirements/reproducible-linux.txt" && \
+  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install "./aws-sam-cli-${SAM_CLI_VERSION}" && \
+  rm ./samcli.zip && rm -rf "./aws-sam-cli-${SAM_CLI_VERSION}"
+
+ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+
+ENV LANG=en_US.UTF-8
+
+# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
+# Python for it to be picked up during `sam build`
+RUN pip3 install wheel
+
+# Set up .NET root
+
+ENV DOTNET_ROOT=/var/lang/bin
+
+# Install .NET build tools
+
+ENV PATH=/root/.dotnet/tools:$PATH \
+    AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    NUGET_XMLDOC_MODE=skip
+
+RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 3.1 -i "${DOTNET_ROOT}" && \
+  mkdir /tmp/warmup && \
+  cd /tmp/warmup && \
+  dotnet new && \
+  cd / && \
+  rm -rf /tmp/warmup /tmp/NuGetScratch /tmp/.dotnet
+
+COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -55,12 +55,10 @@ ENV DOTNET_ROOT=/var/lang/bin
 
 # Install .NET build tools
 
-# Suppress first-time output.
-ENV DOTNET_NOLOGO=true
-
 ENV PATH=/root/.dotnet/tools:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
     NUGET_XMLDOC_MODE=skip
 
 # Warm up the nuget cache once now for faster startup on each use.

--- a/build-image-src/build_all_images.sh
+++ b/build-image-src/build_all_images.sh
@@ -29,3 +29,5 @@ DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile-python39 -t amazon/aws-sam-cli
 docker build -f Dockerfile-ruby25 -t amazon/aws-sam-cli-build-image-ruby2.5 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
 docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
 docker build -f Dockerfile-go1x -t amazon/aws-sam-cli-build-image-go1.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+# Disable DOCKER_CONTENT_TRUST for pulling from public ECR
+DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile-dotnetcore31 -t amazon/aws-sam-cli-build-image-dotnetcore3.1 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .

--- a/tests/apps/dotnetcore3.1/sam-test-app/.gitignore
+++ b/tests/apps/dotnetcore3.1/sam-test-app/.gitignore
@@ -1,0 +1,84 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/osx,linux,windows,dotnetcore
+# Edit at https://www.toptal.com/developers/gitignore?templates=osx,linux,windows,dotnetcore
+
+### DotnetCore ###
+# .NET Core build folders
+bin/
+obj/
+
+# Common node modules locations
+/node_modules
+/wwwroot/node_modules
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/osx,linux,windows,dotnetcore

--- a/tests/apps/dotnetcore3.1/sam-test-app/sam-test-app.sln
+++ b/tests/apps/dotnetcore3.1/sam-test-app/sam-test-app.sln
@@ -1,0 +1,28 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sam-test-app", "src\sam-test-app.csproj", "{73FE859B-8FD9-4533-B6B0-40DFE33BAEA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test", "test\test.csproj", "{0F5F73F7-B2DB-4F7E-9DB0-70B059A3339B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{73FE859B-8FD9-4533-B6B0-40DFE33BAEA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73FE859B-8FD9-4533-B6B0-40DFE33BAEA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73FE859B-8FD9-4533-B6B0-40DFE33BAEA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73FE859B-8FD9-4533-B6B0-40DFE33BAEA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F5F73F7-B2DB-4F7E-9DB0-70B059A3339B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F5F73F7-B2DB-4F7E-9DB0-70B059A3339B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F5F73F7-B2DB-4F7E-9DB0-70B059A3339B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F5F73F7-B2DB-4F7E-9DB0-70B059A3339B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/apps/dotnetcore3.1/sam-test-app/src/Function.cs
+++ b/tests/apps/dotnetcore3.1/sam-test-app/src/Function.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.APIGatewayEvents;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace sam_test_app
+{
+    public class Functions
+    {
+        /// <summary>
+        /// Default constructor that Lambda will invoke.
+        /// </summary>
+        public Functions()
+        {
+        }
+
+
+        /// <summary>
+        /// A Lambda function to respond to HTTP Get methods from API Gateway
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns>The API Gateway response.</returns>
+        public APIGatewayProxyResponse Get(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            context.Logger.LogLine("Get Request\n");
+
+            var response = new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "Hello AWS Serverless",
+                Headers = new Dictionary<string, string> { { "Content-Type", "text/plain" } }
+            };
+
+            return response;
+        }
+    }
+}

--- a/tests/apps/dotnetcore3.1/sam-test-app/src/aws-lambda-tools-defaults.json
+++ b/tests/apps/dotnetcore3.1/sam-test-app/src/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "",
+  "region": "",
+  "configuration": "Release",
+  "framework": "netcoreapp3.1",
+  "s3-prefix": "sam-test-app/",
+  "template": "serverless.template",
+  "template-parameters": ""
+}

--- a/tests/apps/dotnetcore3.1/sam-test-app/src/sam-test-app.csproj
+++ b/tests/apps/dotnetcore3.1/sam-test-app/src/sam-test-app.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+  </ItemGroup>
+</Project>

--- a/tests/apps/dotnetcore3.1/sam-test-app/test/FunctionTest.cs
+++ b/tests/apps/dotnetcore3.1/sam-test-app/test/FunctionTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Xunit;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+using Amazon.Lambda.APIGatewayEvents;
+
+using sam_test_app;
+
+namespace test
+{
+    public class FunctionTest
+    {
+        public FunctionTest()
+        {
+        }
+
+        [Fact]
+        public void TestGetMethod()
+        {
+            TestLambdaContext context;
+            APIGatewayProxyRequest request;
+            APIGatewayProxyResponse response;
+
+            Functions functions = new Functions();
+
+
+            request = new APIGatewayProxyRequest();
+            context = new TestLambdaContext();
+            response = functions.Get(request, context);
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("Hello AWS Serverless", response.Body);
+        }
+    }
+}

--- a/tests/apps/dotnetcore3.1/sam-test-app/test/test.csproj
+++ b/tests/apps/dotnetcore3.1/sam-test-app/test/test.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\sam-test-app.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/apps/dotnetcore3.1/template.yaml
+++ b/tests/apps/dotnetcore3.1/template.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: An AWS Serverless Application.
+Resources:
+  Get:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: sam-test-app::sam_test_app.Functions::Get
+      Runtime: dotnetcore3.1
+      CodeUri: ''
+      MemorySize: 256
+      Timeout: 30
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      Events:
+        RootGet:
+          Type: Api
+          Properties:
+            Path: /
+            Method: GET
+Outputs:
+  ApiURL:
+    Description: API endpoint URL for Prod environment
+    Value: !Sub 'https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/'

--- a/tests/apps/dotnetcore3.1/template.yaml
+++ b/tests/apps/dotnetcore3.1/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       Handler: sam-test-app::sam_test_app.Functions::Get
       Runtime: dotnetcore3.1
-      CodeUri: ''
+      CodeUri: ./src/
       MemorySize: 256
       Timeout: 30
       Policies:

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -161,6 +161,7 @@ class TestBIPython38(BuildImageBase):
         self.assertTrue(self.check_package_output("python --version", "Python 3.8."))
         self.assertTrue(self.is_package_present("pip"))
 
+
 class TestBIPython39(BuildImageBase):
     __test__ = True
 
@@ -174,8 +175,6 @@ class TestBIPython39(BuildImageBase):
         """
         self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
         self.assertTrue(self.is_package_present("pip"))
-
-
 
 
 class TestBIDotNetCore31(BuildImageBase):

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -1,4 +1,4 @@
-from build_image_base_test import BuildImageBase
+from tests.build_image_base_test import BuildImageBase
 
 
 class TestBIJava8(BuildImageBase):
@@ -175,6 +175,22 @@ class TestBIPython39(BuildImageBase):
         self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
         self.assertTrue(self.is_package_present("pip"))
 
+
+
+
+class TestBIDotNetCore31(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("dotnetcore3.1", "Dockerfile-dotnetcore31")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("dotnet --version", "3.1"))
+        self.assertTrue(self.is_package_present("dotnet"))
 
 class TestBIRuby25(BuildImageBase):
     __test__ = True


### PR DESCRIPTION
...and Get `make pr` to Work

*Issue #, if available:* #13

*Description of changes:*

Adds a `dotnetcore3.1` build image in the style of the other build images – pulling its base from Public ECR as Python 3.9 does. The pre-invocation of `dotnet` is from LambCI, and attributed appropriately.

*Notes:*

- It took some effort to to get `make pr` working correctly. I tried to keep the changes for that to a minimum.
- `pytest` wants the unit tests to be run in random order. I don't know enough about it to know whether that plugin is loaded for everyone or just for me, so I did not add it.
- I don't know how these get mirrored to Public ECR, but it should end up there, too. Not only on Docker Hub.
- I set `AWS_EXECUTION_ENV=AWS_Lambda_dotnetcore3.1` for the build image, but that should be set in the emulation image, or whatever it is that's used for `sam local invoke`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
