### PR TITLE
Apple Silicon and basic cross compiling support

### DIFF
--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -42,7 +42,11 @@ RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zi
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
   rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Install cargo and other Rust friends
+RUN curl -L "https://sh.rustup.rs" -o "rustup.sh"
+RUN chmod +x rustup.sh && sh rustup.sh -y
+
+ENV PATH=$PATH:/usr/local/opt/sam-cli/bin:$HOME/.cargo/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -42,12 +42,6 @@ RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zi
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
   rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
 
-# Install cargo and other Rust friends
-RUN curl -L "https://sh.rustup.rs" -o "rustup.sh"
-RUN chmod +x rustup.sh && sh rustup.sh -y
-
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin:$HOME/.cargo/bin
-
 ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system

--- a/build-image-src/Dockerfile-provided-al2
+++ b/build-image-src/Dockerfile-provided-al2
@@ -42,6 +42,8 @@ RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zi
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
   rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
 
+ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+
 ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system

--- a/build-image-src/build_all_images.sh
+++ b/build-image-src/build_all_images.sh
@@ -12,20 +12,28 @@ else
     echo "SAM CLI VERSION: $SAM_CLI_VERSION";
 fi
 
-docker build -f Dockerfile-nodejs10x -t amazon/aws-sam-cli-build-image-nodejs10.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-java8 -t amazon/aws-sam-cli-build-image-java8 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-provided -t amazon/aws-sam-cli-build-image-provided --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-python27 -t amazon/aws-sam-cli-build-image-python2.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-python36 -t amazon/aws-sam-cli-build-image-python3.6 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-python37 -t amazon/aws-sam-cli-build-image-python3.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+if [ ${SAM_CLI_CROSS_BUILD} ];
+then
+    CROSS_DOCKER_BUILDX="buildx"
+    HOST_PLATFORM="`uname -o`/`uname -m`"
+    GUEST_PLATFORM="--platform=linux/amd64"
+    echo "Cross compiling of SAM CLI activated. Host is " ${HOST_PLATFORM} " with target platform flag set to: " ${GUEST_PLATFORM}
+fi
+
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-nodejs10x -t amazon/aws-sam-cli-build-image-nodejs10.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-java8 -t amazon/aws-sam-cli-build-image-java8 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-provided -t amazon/aws-sam-cli-build-image-provided --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-python27 -t amazon/aws-sam-cli-build-image-python2.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-python36 -t amazon/aws-sam-cli-build-image-python3.6 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-python37 -t amazon/aws-sam-cli-build-image-python3.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
 # Disable DOCKER_CONTENT_TRUST for pulling from public ECR
-DOCKER_CONTENT_TRUST=0 docker build -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-ruby25 -t amazon/aws-sam-cli-build-image-ruby2.5 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-docker build -f Dockerfile-go1x -t amazon/aws-sam-cli-build-image-go1.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+DOCKER_CONTENT_TRUST=0 docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-ruby25 -t amazon/aws-sam-cli-build-image-ruby2.5 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker ${CROSS_DOCKER_BUILDX} build ${GUEST_PLATFORM} -f Dockerfile-go1x -t amazon/aws-sam-cli-build-image-go1.x --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .


### PR DESCRIPTION
Followup from https://github.com/aws/aws-sam-cli/issues/3132, refer to that issue and @jfuss for context.

This PR adds the possibility to build the docker images on Apple Silicon, by activating the environment variable:

```shell
$ export SAM_CLI_CROSS_BUILD=1
```

Otherwise none of the containers in `build-image-src/build_all_images.sh` will successfully build on an Apple M1 machine (Darwin/arm64). Some of the errors of not including `buildx` in the docker image building process include the following, predictably:

```shell
(...)
#8 43.57 ---> Package binutils.aarch64 0:2.29.1-30.amzn2 will be installed
#8 43.57 --> Processing Dependency: libdl.so.2(GLIBC_2.17)(64bit) for package: binutils-2.29.1-30.amzn2.aarch64
#8 43.57 Package: glibc-2.26-48.amzn2.aarch64 - can't co-install with glibc-2.26-48.amzn2.x86_64
#8 43.58 --> Processing Dependency: ld-linux-aarch64.so.1(GLIBC_2.17)(64bit) for package: binutils-2.29.1-30.amzn2.aarch64
#8 43.58 Package: glibc-2.26-48.amzn2.aarch64 - can't co-install with glibc-2.26-48.amzn2.x86_64
#8 43.58 --> Processing Dependency: ld-linux-aarch64.so.1()(64bit) for package: binutils-2.29.1-30.amzn2.aarch64
#8 43.58 Package: glibc-2.26-48.amzn2.aarch64 - can't co-install with glibc-2.26-48.amzn2.x86_64
(...)
```