### PR TITLE
fix: enable all runtimes other than go1.x

### DIFF
--- a/build-image-src/build_all_images.sh
+++ b/build-image-src/build_all_images.sh
@@ -17,37 +17,37 @@ export DOCKER_CONTENT_TRUST=0
 export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Single arch images
-#docker build -f Dockerfile-java8 -t amazon/aws-sam-cli-build-image-java8:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-nodejs10x -t amazon/aws-sam-cli-build-image-nodejs10.x:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-provided -t amazon/aws-sam-cli-build-image-provided:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-python27 -t amazon/aws-sam-cli-build-image-python2.7:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-python36 -t amazon/aws-sam-cli-build-image-python3.6:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-python37 -t amazon/aws-sam-cli-build-image-python3.7:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
-#docker build -f Dockerfile-ruby25 -t amazon/aws-sam-cli-build-image-ruby2.5:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-java8 -t amazon/aws-sam-cli-build-image-java8:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-nodejs10x -t amazon/aws-sam-cli-build-image-nodejs10.x:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-provided -t amazon/aws-sam-cli-build-image-provided:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-python27 -t amazon/aws-sam-cli-build-image-python2.7:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-python36 -t amazon/aws-sam-cli-build-image-python3.6:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-python37 -t amazon/aws-sam-cli-build-image-python3.7:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
+docker build -f Dockerfile-ruby25 -t amazon/aws-sam-cli-build-image-ruby2.5:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
 # Commented out until Let's Encrypt certificate issue fixed
 # docker build -f Dockerfile-go1x -t amazon/aws-sam-cli-build-image-go1.x:x86_64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION .
 
 # Multi arch images
 # First build all x86
 docker build -f Dockerfile-dotnetcore31 -t amazon/aws-sam-cli-build-image-dotnetcore3.1:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
-#docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
+docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 .
 
 # Delete multi arch al2 image and start building arm64 images
 docker rmi public.ecr.aws/amazonlinux/amazonlinux:2
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker build -f Dockerfile-dotnetcore31 -t amazon/aws-sam-cli-build-image-dotnetcore3.1:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
-#docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-java8-al2 -t amazon/aws-sam-cli-build-image-java8.al2:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-java11 -t amazon/aws-sam-cli-build-image-java11:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-nodejs12x -t amazon/aws-sam-cli-build-image-nodejs12.x:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-nodejs14x -t amazon/aws-sam-cli-build-image-nodejs14.x:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-provided-al2 -t amazon/aws-sam-cli-build-image-provided.al2:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-python38 -t amazon/aws-sam-cli-build-image-python3.8:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-python39 -t amazon/aws-sam-cli-build-image-python3.9:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .
+docker build -f Dockerfile-ruby27 -t amazon/aws-sam-cli-build-image-ruby2.7:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 .

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -1,291 +1,291 @@
 from tests.build_image_base_test import BuildImageBase
 
 
-# class TestBIJava8(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("java8", "Dockerfile-java8", "maven")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("java -version", 'openjdk version "1.8', True)
-#         )
-#         self.assertTrue(self.is_package_present("mvn"))
-#         self.assertTrue(self.is_package_present("gradle"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIJava8AL2(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("java8.al2", "Dockerfile-java8-al2", "gradle", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("java -version", 'openjdk version "1.8', True)
-#         )
-#         self.assertTrue(self.is_package_present("mvn"))
-#         self.assertTrue(self.is_package_present("gradle"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIJava8AL2ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("java8.al2", "Dockerfile-java8-al2", "gradle", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("java -version", 'openjdk version "1.8', True)
-#         )
-#         self.assertTrue(self.is_package_present("mvn"))
-#         self.assertTrue(self.is_package_present("gradle"))
-#         self.assertTrue(self.is_architecture("aarch64"))
-#
-#
-# class TestBIJava11(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("java11", "Dockerfile-java11", "maven", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("java -version", 'openjdk version "11.0.', True)
-#         )
-#         self.assertTrue(self.is_package_present("mvn"))
-#         self.assertTrue(self.is_package_present("gradle"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIJava11ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("java11", "Dockerfile-java11", "maven", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("java -version", 'openjdk version "11.0.', True)
-#         )
-#         self.assertTrue(self.is_package_present("mvn"))
-#         self.assertTrue(self.is_package_present("gradle"))
-#         self.assertTrue(self.is_architecture("aarch64"))
-#
-#
-# class TestBINode10(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("nodejs10.x", "Dockerfile-nodejs10x", "npm")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("node --version", "v10."))
-#         self.assertTrue(self.is_package_present("npm"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBINode12(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("nodejs12.x", "Dockerfile-nodejs12x", "npm", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("node --version", "v12."))
-#         self.assertTrue(self.is_package_present("npm"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBINode12ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("nodejs12.x", "Dockerfile-nodejs12x", "npm", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("node --version", "v12."))
-#         self.assertTrue(self.is_package_present("npm"))
-#         self.assertTrue(self.is_architecture("aarch64"))
-#
-#
-# class TestBINode14(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("nodejs14.x", "Dockerfile-nodejs14x", "npm", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("node --version", "v14."))
-#         self.assertTrue(self.is_package_present("npm"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBINode14ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("nodejs14.x", "Dockerfile-nodejs14x", "npm", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("node --version", "v14."))
-#         self.assertTrue(self.is_package_present("npm"))
-#         self.assertTrue(self.is_architecture("aarch64"))
-#
-#
-# class TestBIPython27(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python2.7", "Dockerfile-python27", "pip")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(
-#             self.check_package_output("python --version", "Python 2.7.", True)
-#         )
-#         self.assertTrue(self.is_package_present("pip"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIPython36(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.6", "Dockerfile-python36", "pip")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.6."))
-#         self.assertTrue(self.is_package_present("pip"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIPython37(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.7", "Dockerfile-python37", "pip")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.7."))
-#         self.assertTrue(self.is_package_present("pip"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIPython38(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.8", "Dockerfile-python38", "pip", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.8."))
-#         self.assertTrue(self.is_package_present("pip"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIPython38ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.8", "Dockerfile-python38", "pip", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.8."))
-#         self.assertTrue(self.is_package_present("pip"))
-#         self.assertTrue(self.is_architecture("aarch64"))
-#
-#
-# class TestBIPython39(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.9", "Dockerfile-python39", "pip", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
-#         self.assertTrue(self.is_package_present("pip"))
-#
-#
-# class TestBIPython39ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("python3.9", "Dockerfile-python39", "pip", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
-#         self.assertTrue(self.is_package_present("pip"))
+class TestBIJava8(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("java8", "Dockerfile-java8", "maven")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("java -version", 'openjdk version "1.8', True)
+        )
+        self.assertTrue(self.is_package_present("mvn"))
+        self.assertTrue(self.is_package_present("gradle"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIJava8AL2(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("java8.al2", "Dockerfile-java8-al2", "gradle", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("java -version", 'openjdk version "1.8', True)
+        )
+        self.assertTrue(self.is_package_present("mvn"))
+        self.assertTrue(self.is_package_present("gradle"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIJava8AL2ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("java8.al2", "Dockerfile-java8-al2", "gradle", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("java -version", 'openjdk version "1.8', True)
+        )
+        self.assertTrue(self.is_package_present("mvn"))
+        self.assertTrue(self.is_package_present("gradle"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
+
+class TestBIJava11(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("java11", "Dockerfile-java11", "maven", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("java -version", 'openjdk version "11.0.', True)
+        )
+        self.assertTrue(self.is_package_present("mvn"))
+        self.assertTrue(self.is_package_present("gradle"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIJava11ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("java11", "Dockerfile-java11", "maven", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("java -version", 'openjdk version "11.0.', True)
+        )
+        self.assertTrue(self.is_package_present("mvn"))
+        self.assertTrue(self.is_package_present("gradle"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
+
+class TestBINode10(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("nodejs10.x", "Dockerfile-nodejs10x", "npm")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("node --version", "v10."))
+        self.assertTrue(self.is_package_present("npm"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBINode12(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("nodejs12.x", "Dockerfile-nodejs12x", "npm", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("node --version", "v12."))
+        self.assertTrue(self.is_package_present("npm"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBINode12ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("nodejs12.x", "Dockerfile-nodejs12x", "npm", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("node --version", "v12."))
+        self.assertTrue(self.is_package_present("npm"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
+
+class TestBINode14(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("nodejs14.x", "Dockerfile-nodejs14x", "npm", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("node --version", "v14."))
+        self.assertTrue(self.is_package_present("npm"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBINode14ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("nodejs14.x", "Dockerfile-nodejs14x", "npm", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("node --version", "v14."))
+        self.assertTrue(self.is_package_present("npm"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
+
+class TestBIPython27(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python2.7", "Dockerfile-python27", "pip")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(
+            self.check_package_output("python --version", "Python 2.7.", True)
+        )
+        self.assertTrue(self.is_package_present("pip"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIPython36(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.6", "Dockerfile-python36", "pip")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.6."))
+        self.assertTrue(self.is_package_present("pip"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIPython37(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.7", "Dockerfile-python37", "pip")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.7."))
+        self.assertTrue(self.is_package_present("pip"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIPython38(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.8", "Dockerfile-python38", "pip", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.8."))
+        self.assertTrue(self.is_package_present("pip"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIPython38ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.8", "Dockerfile-python38", "pip", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.8."))
+        self.assertTrue(self.is_package_present("pip"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
+
+class TestBIPython39(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.9", "Dockerfile-python39", "pip", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
+        self.assertTrue(self.is_package_present("pip"))
+
+
+class TestBIPython39ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("python3.9", "Dockerfile-python39", "pip", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("python --version", "Python 3.9."))
+        self.assertTrue(self.is_package_present("pip"))
 
 
 class TestBIDotNetCore31(BuildImageBase):
@@ -303,55 +303,55 @@ class TestBIDotNetCore31(BuildImageBase):
         self.assertTrue(self.is_package_present("dotnet"))
 
 
-# class TestBIRuby25(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("ruby2.5", "Dockerfile-ruby25", "bundler")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("ruby --version", "ruby 2.5."))
-#         self.assertTrue(self.is_package_present("bundler"))
-#         self.assertTrue(self.is_package_present("gem"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIRuby27(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("ruby2.7", "Dockerfile-ruby27", "bundler", tag="x86_64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("ruby --version", "ruby 2.7."))
-#         self.assertTrue(self.is_package_present("bundler"))
-#         self.assertTrue(self.is_package_present("gem"))
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIRuby27ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("ruby2.7", "Dockerfile-ruby27", "bundler", tag="arm64")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("ruby --version", "ruby 2.7."))
-#         self.assertTrue(self.is_package_present("bundler"))
-#         self.assertTrue(self.is_package_present("gem"))
-#         self.assertTrue(self.is_architecture("aarch64"))
+class TestBIRuby25(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("ruby2.5", "Dockerfile-ruby25", "bundler")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("ruby --version", "ruby 2.5."))
+        self.assertTrue(self.is_package_present("bundler"))
+        self.assertTrue(self.is_package_present("gem"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIRuby27(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("ruby2.7", "Dockerfile-ruby27", "bundler", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("ruby --version", "ruby 2.7."))
+        self.assertTrue(self.is_package_present("bundler"))
+        self.assertTrue(self.is_package_present("gem"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIRuby27ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("ruby2.7", "Dockerfile-ruby27", "bundler", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("ruby --version", "ruby 2.7."))
+        self.assertTrue(self.is_package_present("bundler"))
+        self.assertTrue(self.is_package_present("gem"))
+        self.assertTrue(self.is_architecture("aarch64"))
 
 
 # Commented out until Let's Encrypt certificate issue fixed
@@ -370,37 +370,37 @@ class TestBIDotNetCore31(BuildImageBase):
 #         self.assertTrue(self.is_package_present("go"))
 
 
-# class TestBIProvided(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("provided", "Dockerfile-provided")
-#
-#
-# class TestBIProvidedAL2(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("provided.al2", "Dockerfile-provided-al2", tag="x86_64")
-#
-#     def test_architecture(self):
-#         """
-#         Test architecture of this build image
-#         """
-#         self.assertTrue(self.is_architecture("x86_64"))
-#
-#
-# class TestBIProvidedAL2ForArm(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("provided.al2", "Dockerfile-provided-al2", tag="arm64")
-#
-#     def test_architecture(self):
-#         """
-#         Test architecture of this build image
-#         """
-#         self.assertTrue(self.is_architecture("aarch64"))
+class TestBIProvided(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("provided", "Dockerfile-provided")
+
+
+class TestBIProvidedAL2(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("provided.al2", "Dockerfile-provided-al2", tag="x86_64")
+
+    def test_architecture(self):
+        """
+        Test architecture of this build image
+        """
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+class TestBIProvidedAL2ForArm(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("provided.al2", "Dockerfile-provided-al2", tag="arm64")
+
+    def test_architecture(self):
+        """
+        Test architecture of this build image
+        """
+        self.assertTrue(self.is_architecture("aarch64"))


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
