### PR TITLE
fix: increase docker client timeout

### DIFF
--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -22,7 +22,7 @@ class BuildImageBase(TestCase):
         cls.app_location = f"tests/apps/{runtime}"
         cls.runtime = runtime
         cls.dep_manager = dep_manager
-        cls.client = docker.from_env()
+        cls.client = docker.from_env(timeout=300)
         cls.sam_version = os.getenv("SAM_CLI_VERSION")
         TestCase().assertTrue(
             cls.sam_version


### PR DESCRIPTION
Docker client times out during images.prune call. This PR adjusts 60s default timeout value


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
