### PR TITLE
feat: use native linux installer for py36 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build-multi-arch: pre-build
 	docker build -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 ./build-image-src
 
 test: pre-build
-	pytest tests -m $(RUNTIME)
+	pytest tests -vv -m $(RUNTIME)
 
 lint:
 	# Linter performs static analysis to catch latent bugs

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -49,7 +49,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && python3 -m venv /usr/local/opt/lambda-builders && /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
-ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
+RUN ln -s /usr/local/opt/lambda-builders/bin/lambda-builders /usr/local/bin/
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -40,13 +40,13 @@ RUN chmod 1777 /tmp && \
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI via native linux installer
 ARG SAM_CLI_VERSION
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
-# Install lambda builders
+# Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && python3 -m venv /usr/local/opt/lambda-builders && /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -47,9 +47,10 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && python3 -m venv /usr/local/opt/lambda-builders && /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
-
-RUN ln -s /usr/local/opt/lambda-builders/bin/lambda-builders /usr/local/bin/
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  python3 -m venv /usr/local/opt/lambda-builders && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION" && \
+  ln -s /usr/local/opt/lambda-builders/bin/lambda-builders /usr/local/bin/
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python36
+++ b/build-image-src/Dockerfile-python36
@@ -42,13 +42,14 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Install lambda builders
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && python3 -m venv /usr/local/opt/lambda-builders && /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
For python3.6 runtime, switch to use native linux installer for SAM CLI. And create another virtual environment for Lambda Builders to install it into that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
