### PR TITLE
feat: use native SAM CLI installer for all x86 only images

### DIFF
--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -33,13 +33,17 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  python3 -m venv /usr/local/opt/lambda-builders && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION" && \
+  ln -s /usr/local/opt/lambda-builders/bin/lambda-builders /usr/local/bin/
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -31,7 +31,7 @@ ENV GOPROXY=direct
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI via native linux installer
 ARG SAM_CLI_VERSION
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
@@ -40,8 +40,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
   python3 -m venv /usr/local/opt/lambda-builders && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION" && \
-  ln -s /usr/local/opt/lambda-builders/bin/lambda-builders /usr/local/bin/
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -43,7 +43,7 @@ RUN chmod 1777 /tmp && \
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm -rf awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI via native linux installer
 ARG SAM_CLI_VERSION
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -45,13 +45,16 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  python3 -m venv /usr/local/opt/lambda-builders && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -43,13 +43,16 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  python3 -m venv /usr/local/opt/lambda-builders && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -41,7 +41,7 @@ RUN chmod 1777 /tmp && \
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI via native linux installer
 ARG SAM_CLI_VERSION
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
For python3.6 runtime, switch to use native linux installer for SAM CLI. And create another virtual environment for Lambda Builders to install it into that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
