### PR TITLE
fix: add dep_manager for dotnet runtimes for sam init

### DIFF
--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -311,7 +311,7 @@ class TestBIDotNetCore31(BuildImageBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass("dotnetcore3.1", "Dockerfile-dotnetcore31", tag="x86_64")
+        super().setUpClass("dotnetcore3.1", "Dockerfile-dotnetcore31", tag="x86_64", dep_manager="cli-package")
 
     def test_packages(self):
         """
@@ -327,7 +327,7 @@ class TestBIDotNetCore31Arm(BuildImageBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass("dotnetcore3.1", "Dockerfile-dotnetcore31", tag="arm64")
+        super().setUpClass("dotnetcore3.1", "Dockerfile-dotnetcore31", tag="arm64", dep_manager="cli-package")
 
     def test_packages(self):
         """
@@ -342,7 +342,7 @@ class TestBIDotNet6(BuildImageBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass("dotnet6", "Dockerfile-dotnet6", tag="x86_64")
+        super().setUpClass("dotnet6", "Dockerfile-dotnet6", tag="x86_64", dep_manager="cli-package")
 
     def test_packages(self):
         """
@@ -358,7 +358,7 @@ class TestBIDotNet6Arm(BuildImageBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass("dotnet6", "Dockerfile-dotnet6", tag="arm64")
+        super().setUpClass("dotnet6", "Dockerfile-dotnet6", tag="arm64", dep_manager="cli-package")
 
     def test_packages(self):
         """


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add `--dependency-manager` option for `sam init` command for dotnet runtimes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
