### PR TITLE
fix: use correct arch type for AWS CLI installation

### DIFF
--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -33,7 +33,8 @@ FROM public.ecr.aws/sam/emulation-dotnet6:latest-$IMAGE_ARCH
 COPY --from=1 /rootfs /
 
 # Install AWS CLI
-RUN curl 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o ./awscliv2.zip && unzip ./awscliv2.zip && ./aws/install && rm ./awscliv2.zip && rm -rf ./aws
+ARG AWS_CLI_ARCH
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
