### PR TITLE
Update to .NET 7 base image and add back test

### DIFF
--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:6-x86_64
+FROM public.ecr.aws/lambda/dotnet:7
 
 RUN yum groupinstall -y development && \
   yum install -d1 -y \

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -71,7 +71,7 @@ class BuildImageBase(TestCase):
         """
         Test sam init hello world application for the given runtime and dependency manager
         """
-        if self.runtime in ["provided", "provided.al2"]:
+        if self.runtime in ["provided", "provided.al2", "dotnet7"]:
             pytest.skip("Skipping sam init test for self-provided images")
 
         sam_init = f"sam init \

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -368,28 +368,20 @@ class TestBIDotNet6Arm(BuildImageBase):
         self.assertTrue(self.is_package_present("dotnet"))
 
 
-# Uncomment this after .NET 7 release, and remove dummy test below, and remove preview from image description
-# @pytest.mark.dotnet7
-# class TestBIDotNet7(BuildImageBase):
-#     __test__ = True
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         super().setUpClass("dotnet7", "Dockerfile-dotnet7", tag="x86_64", dep_manager="cli-package")
-#
-#     def test_packages(self):
-#         """
-#         Test packages specific to this build image
-#         """
-#         self.assertTrue(self.check_package_output("dotnet --version", "7"))
-#         self.assertTrue(self.is_package_present("dotnet"))
-
-
 @pytest.mark.dotnet7
-class TestBIDotNet7(TestCase):
+class TestBIDotNet7(BuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("dotnet7", "Dockerfile-dotnet7", tag="x86_64", dep_manager="cli-package")
 
     def test_packages(self):
-        self.assertTrue(True)
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("dotnet --version", "7"))
+        self.assertTrue(self.is_package_present("dotnet"))
 
 
 @pytest.mark.ruby27


### PR DESCRIPTION
*Description of changes:* Now that the image 'public.ecr.aws/lambda/dotnet:7' is available, we can use that for the base image of the .NET 7 build image. We can also add back the test for dotnet7 once BuildMethod:dotnet7 is supported


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
