### PR TITLE
chore: Remove type/bug label for Bug Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create an issue to report a bug for AWS SAM build images
 title: "Bug: TITLE"
-labels: ['type/bug', 'stage/needs-triage']
+labels: ['stage/needs-triage']
 assignees: ''
 
 ---


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 Main reason is for how we track bugs. We first want to validate the bug before adding the label.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
