### PR TITLE
fix: update python version in older images to use new aws-lambda-builders version

### DIFF
--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python38.x86_64 \
+  python38 \
   jq \
   git \
   grep \

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
+  python3.7 \
   jq \
   git \
   grep \

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -37,9 +37,12 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=1.26.0 && \
-  python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3.7 \
+  python38.x86_64 \
   jq \
   git \
   grep \

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -38,7 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+RUN AWS_LB_VERSION=1.26.0 && \
   python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -42,7 +42,7 @@ RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=1.26.0 && \
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -40,7 +40,7 @@ RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=1.26.0 && \
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python38.x86_64 \
+  python38 \
   jq \
   grep \
   curl \
@@ -35,9 +35,12 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=1.26.0 && \
-  python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3.7 \
+  python38.x86_64 \
   jq \
   grep \
   curl \

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -36,7 +36,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+RUN AWS_LB_VERSION=1.26.0 && \
   python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
+  python3.7 \
   jq \
   grep \
   curl \

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -35,7 +35,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+RUN AWS_LB_VERSION=1.26.0 && \
   python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3.7 \
+  python38.x86_64 \
   jq \
   grep \
   curl \

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -40,7 +40,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=1.26.0 && \
-  python3 -m venv /usr/local/opt/lambda-builders && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -39,7 +39,7 @@ RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-RUN AWS_LB_VERSION=1.26.0 && \
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
   /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
+  python3.7 \
   jq \
   grep \
   curl \

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -34,6 +34,10 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=1.26.0 && \
   python3 -m venv /usr/local/opt/lambda-builders && \

--- a/build-image-src/Dockerfile-provided
+++ b/build-image-src/Dockerfile-provided
@@ -5,7 +5,7 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python38.x86_64 \
+  python38 \
   jq \
   grep \
   curl \


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Old build images (`java8`, `provided` and `go1.x`) is still have `python3.6` as default `python3` version. With latest release of `aws-lambda-builders`, `python3.7+` versions are supported. This PR is addressing that issue by installing `python3.8` and its dependencies required for creating virtual environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
