### PR TITLE
feat: add environment variables to docker images to support dotnet container builds

### DIFF
--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -77,6 +77,15 @@ RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
 
 COPY ATTRIBUTION.txt /
 
+# Runtime environment variables need to be defined after installation of all dotnet tools.
+# These variables define the tmp home directory for .NET CLI and the migration directory for NuGet in container.
+# .NET `sam build` requires tmp diretories being set for current user because it runs docker
+# as current/non-root user (unless current user is root) on posix systems.
+# That user will make/own these directory in container during the runtime.
+# They work the same as using docker arguments `-e DOTNET_CLI_HOME=/tmp/dotnet XDG_DATA_HOME=/tmp/xdg`
+ENV DOTNET_CLI_HOME=/tmp/dotnet
+ENV XDG_DATA_HOME=/tmp/xdg
+
 # Compatible with initial base image
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -79,6 +79,15 @@ RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
 
 COPY ATTRIBUTION.txt /
 
+# Runtime environment variables need to be defined after installation of all dotnet tools.
+# These variables define the tmp home directory for .NET CLI and the migration directory for NuGet in container.
+# .NET `sam build` requires tmp diretories being set for current user because it runs docker
+# as current/non-root user (unless current user is root) on posix systems.
+# That user will make/own these directory in container during the runtime.
+# They work the same as using docker arguments `-e DOTNET_CLI_HOME=/tmp/dotnet XDG_DATA_HOME=/tmp/xdg`
+ENV DOTNET_CLI_HOME=/tmp/dotnet
+ENV XDG_DATA_HOME=/tmp/xdg
+
 # Compatible with initial base image
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/build-image-src/Dockerfile-dotnetcore31
+++ b/build-image-src/Dockerfile-dotnetcore31
@@ -77,6 +77,15 @@ RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
 
 COPY ATTRIBUTION.txt /
 
+# Runtime environment variables need to be defined after installation of all dotnet tools.
+# These variables define the tmp home directory for .NET CLI and the migration directory for NuGet in container.
+# .NET `sam build` requires tmp diretories being set for current user because it runs docker
+# as current/non-root user (unless current user is root) on posix systems.
+# That user will make/own these directory in container during the runtime.
+# They work the same as using docker arguments `-e DOTNET_CLI_HOME=/tmp/dotnet XDG_DATA_HOME=/tmp/xdg`
+ENV DOTNET_CLI_HOME=/tmp/dotnet
+ENV XDG_DATA_HOME=/tmp/xdg
+
 # Compatible with initial base image
 ENTRYPOINT []
 CMD ["/bin/bash"]


### PR DESCRIPTION
*Issue #, if available:*
Companion to SAM CLI feature https://github.com/aws/aws-sam-cli/pull/4665.

*Description of changes:*

As mentioned in [side effects](https://github.com/aws/aws-sam-cli/pull/4665#issue-1573520155), SAM CLI relies on .NET images to define `DOTNET_CLI_HOME` and `XDG_DATA_HOME`. This change adds environment variables in all .NET images. The environment variables define temporary directories `DOTNET_CLI_HOME` and `XDG_DATA_HOME` in container during the runtime. So the current user who is running docker will make/own these directories and have proper permissions.

These images are used by SAM CLI when no customer images. This change won't break anything for SAM CLI since docker builds weren't supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
