### PR TITLE
ci: add feat* rule to run github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,15 @@
 name: Build & Test
 
 on:
-  pull_request
+  pull_request:
+    branches:
+      - develop
+      - "feat*"
+  merge_group:
+    types: [ checks_requested ]
+    branches:
+      - develop
+      - "feat*"
 
 jobs:
   run-workflow:


### PR DESCRIPTION
Enable GHA CI jobs to run against `develop` and `feat*` branches.
Setup merge-queue config for the future.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
