### PR TITLE
fix: set GRADLE_OPTS and MAVEN_OPTS to fix build issues with java17 & arm64

### DIFF
--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -57,6 +57,10 @@ ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.8
 
 COPY ATTRIBUTION.txt /
 
+# Set following GRADLE_OPTS and MAVEN_OPTS to fix issues with arm64 image
+ENV GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+ENV MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+
 # Compatible with initial base image
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -76,8 +76,6 @@ class BuildImageBase(TestCase):
         """
         Test sam init hello world application for the given runtime and dependency manager
         """
-        if self.runtime == "java17" and self.tag == "arm64":
-            pytest.skip("Skipping java17-arm64 tests for sam init flow")
         if self.runtime in ["provided", "provided.al2", "dotnet7"]:
             pytest.skip("Skipping sam init test for self-provided images")
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/5055

*Description of changes:*
This PR sets `-Djdk.lang.Process.launchMechanism=vfork` JVM option for both Maven & Gradle through `MAVEN_OPTS` and `GRADLE_OPTS` environment variables which resolves issues when running arm64 builds from x86 host.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
