### PR TITLE
Add diagnostic logging to .NET Amazon.Lambda.Tools install

### DIFF
--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -77,7 +77,9 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 7.0 -i "${DOTNE
 #   `sam build`) will pick up the newly installed, globally installed version of the tool.
 ENV PATH=~/.dotnet/tools:$PATH
 
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
+# We're using the -v diag argument to output extra logs because in the past we've seen intermittent failures
+# and want to be able to better understand them if they happen again
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools -v diag
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
*Description of changes:* Calls to `dotnet tool install` were failing without a specific error code or stack trace, so we're adding this to make sure we can get more information if it happens again.

Previous failure looked like this:
```
Step 15/20 : RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
 ---> Running in 571c3a8cdfbb
The tool package could not be restored.
Tool 'amazon.lambda.tools' failed to install. This failure may have been caused by:
* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.
For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool
The command '/bin/sh -c dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools' returned a non-zero code: 1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
