### PR TITLE
chore: add ruby32 to ci jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
           - "python39"
           - "python310"
           - "ruby27"
+          - "ruby32"
     runs-on: ubuntu-latest
     needs: [get-sam-cli-version]
     steps:


### PR DESCRIPTION
Add missing CI jobs for ruby32 runtime


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
