### PR TITLE
fix: pin cython for building pyyaml from source

### DIFF
--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -27,9 +27,11 @@ ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
 # Install SAM CLI in a dedicated Python virtualenv
+# Note: Remove cython<3.0.0 line once the issue with building pyyaml from source is fixed
 ARG SAM_CLI_VERSION
 RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
   unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
+  /usr/local/opt/sam-cli/bin/pip3 install wheel && /usr/local/opt/sam-cli/bin/pip3 install --no-build-isolation "cython<3.0.0" pyyaml==5.4.1 && /usr/local/opt/sam-cli/bin/pip3 uninstall wheel cython --yes && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
   rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/aws/aws-sam-cli/pull/5494, https://github.com/aws/aws-sam-cli/pull/5544

*Description of changes:*
Install `cython<3.0.0` and `wheel` to fix issues when building `pyyaml` from source.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
