### PR TITLE
chore: pin the parent images for Java8 and Go1.x runtimes

### DIFF
--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -1,4 +1,6 @@
-FROM public.ecr.aws/lambda/go:1
+# reset to the latest emulation image after the raised issue got solved.
+# FROM public.ecr.aws/lambda/go:1
+FROM public.ecr.aws/lambda/go:1.2023.08.02.10
 
 RUN yum groupinstall -y development && \
   yum install -d1 -y \

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -1,4 +1,6 @@
-FROM public.ecr.aws/lambda/java:8
+# reset to the latest emulation image after the raised issue got solved.
+# FROM public.ecr.aws/lambda/java:8
+FROM public.ecr.aws/lambda/java:8.2023.08.02.10
 
 RUN yum groupinstall -y development && \
   yum install -d1 -y \


### PR DESCRIPTION
pin the parent images for Java8 and Go1.x runtimes to old emulation images till runtimes team fix the latest images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
