### PR TITLE
feat: improve java build time by pre-creating gradle cache files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ else
 endif
 
 build-single-arch: pre-build
-	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) ./build-image-src
+	docker build --progress=plain -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) ./build-image-src
 
 build-multi-arch: pre-build
-	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 ./build-image-src
+	docker build --progress=plain -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 ./build-image-src
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 ./build-image-src
+	docker build --progress=plain -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 ./build-image-src
 
 test: pre-build
 	pytest tests -vv -m $(RUNTIME)

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ else
 endif
 
 build-single-arch: pre-build
-	docker build -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) ./build-image-src
+	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) ./build-image-src
 
 build-multi-arch: pre-build
-	docker build -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 ./build-image-src
+	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 ./build-image-src
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker build -f build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 ./build-image-src
+	docker build -f --progress=plain build-image-src/Dockerfile-$(RUNTIME) -t amazon/aws-sam-cli-build-image-$(IS_$(RUNTIME)):arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$(SAM_CLI_VERSION) --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 ./build-image-src
 
 test: pre-build
 	pytest tests -vv -m $(RUNTIME)

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -58,7 +58,7 @@ ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8
 # Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
 # to improve performance when using these images
 RUN touch build.gradle.kts
-RUN gradle build; exit 0
+RUN gradle prepareKotlinBuildScriptModel
 RUN rm -rf * .gradle
 
 # Set following GRADLE_OPTS for performance improvement

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -61,6 +61,9 @@ RUN touch build.gradle.kts
 RUN gradle build; exit 0
 RUN rm -rf * .gradle
 
+# Set following GRADLE_OPTS for performance improvement
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+
 COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -55,6 +55,12 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.or
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
 
+# Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
+# to improve performance when using these images
+RUN touch build.gradle.kts
+RUN gradle build; exit 0
+RUN rm -rf * .gradle
+
 COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -61,11 +61,11 @@ RUN touch build.gradle.kts
 RUN gradle build; exit 0
 RUN rm -rf * .gradle
 
-COPY ATTRIBUTION.txt /
-
 # Set following GRADLE_OPTS and MAVEN_OPTS to fix issues with arm64 image
-ENV GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+ENV GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork -Dorg.gradle.daemon=false"
 ENV MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+
+COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -58,7 +58,7 @@ ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.8
 # Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
 # to improve performance when using these images
 RUN touch build.gradle.kts
-RUN gradle build; exit 0
+RUN gradle prepareKotlinBuildScriptModel
 RUN rm -rf * .gradle
 
 # Set following GRADLE_OPTS and MAVEN_OPTS to fix issues with arm64 image

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -62,6 +62,7 @@ RUN gradle build; exit 0
 RUN rm -rf * .gradle
 
 # Set following GRADLE_OPTS and MAVEN_OPTS to fix issues with arm64 image
+# Disable gradle daemon for performance improvement
 ENV GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork -Dorg.gradle.daemon=false"
 ENV MAVEN_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -55,6 +55,12 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.or
 
 ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
 
+# Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
+# to improve performance when using these images
+RUN touch build.gradle.kts
+RUN gradle build; exit 0
+RUN rm -rf * .gradle
+
 COPY ATTRIBUTION.txt /
 
 # Set following GRADLE_OPTS and MAVEN_OPTS to fix issues with arm64 image

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -60,7 +60,7 @@ ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8
 # Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
 # to improve performance when using these images
 RUN touch build.gradle.kts
-RUN gradle build; exit 0
+RUN gradle prepareKotlinBuildScriptModel
 RUN rm -rf * .gradle
 
 # Set following GRADLE_OPTS for performance improvement

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -63,6 +63,9 @@ RUN touch build.gradle.kts
 RUN gradle build; exit 0
 RUN rm -rf * .gradle
 
+# Set following GRADLE_OPTS for performance improvement
+ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+
 COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -57,6 +57,12 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.or
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
 
+# Build a dummy gradle kotling project to cache gradle-api.jar and gradle-kotlin-dsl-extensions.jar
+# to improve performance when using these images
+RUN touch build.gradle.kts
+RUN gradle build; exit 0
+RUN rm -rf * .gradle
+
 COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Disable gradle daemon to improve performance: https://docs.gradle.org/current/userguide/gradle_daemon.html#disable_globally
Pre-create some of the JAR files which is usually created when a Kotlin-DSL based `build.gradle` is provided. https://github.com/gradle/gradle/issues/19565


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
