### PR TITLE
chore: Update Python version for images that install SAM CLI from source

### DIFF
--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,8 +18,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -24,7 +24,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -24,6 +24,8 @@ RUN yum groupinstall -y development && \
   llvm \
   libicu
 
+RUN yum remove -y python3 python3-devel
+
 # Install extras so that Python 3.8 is installable
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -28,7 +28,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,12 +18,22 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
+  amazon-linux-extras \
   clang krb5-devel \
   openssl-devel \
   llvm \
-  libicu \
-  && yum clean all
+  libicu
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,8 +18,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -24,7 +24,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,8 +18,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -24,7 +24,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -27,7 +27,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -21,9 +20,19 @@ RUN yum groupinstall -y development && \
   liblzma-dev \
   libxslt-devel \
   libmpc-devel \
-  python3-devel \
-  java-1.8.0-openjdk-devel \
-  && yum clean all
+  amazon-linux-extras \
+  java-1.8.0-openjdk-devel
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -12,7 +12,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -24,8 +23,15 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras install -y python3.8 && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -27,7 +27,10 @@ RUN yum groupinstall -y development && \
 
 # Install extras so that Python 3.8 is installable
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras install -y python3.8 && \
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python38 python38-devel && \
+  yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
   python3 --version && \

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -12,7 +12,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -24,8 +23,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python38 python38-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -33,7 +42,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "a
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
+RUN curl -L "https://github.com/lucashuy/aws-sam-cli/archive/$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
   unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -42,7 +42,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "a
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/lucashuy/aws-sam-cli/archive/$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
+RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
   unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
   /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -12,7 +12,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -24,8 +23,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -29,7 +29,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -29,7 +29,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -6,14 +6,12 @@ ENV PATH=/var/lang/bin:$PATH \
     AWS_EXECUTION_ENV=AWS_Lambda_nodejs18.x \
     NODE_PATH=/opt/nodejs/node18/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-# Installing by yum at copied location
 RUN yum groupinstall -y development && \
   yum install -d1 -y \
   yum \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -25,8 +23,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -21,8 +20,18 @@ RUN yum groupinstall -y development && \
   liblzma-dev \
   libxslt-devel \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -26,7 +26,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-python37
+++ b/build-image-src/Dockerfile-python37
@@ -27,17 +27,23 @@ RUN yum groupinstall -y development && \
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI via native linux installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
-
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-x86_64.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
 ENV LANG=en_US.UTF-8
+
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -24,7 +24,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,8 +18,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 RUN gem update --system --no-document
 

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -24,7 +24,7 @@ RUN yum groupinstall -y development && \
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
 RUN amazon-linux-extras enable python3.8 && \
   yum clean metadata && \
-  yum install -y python3.8 python3.8-devel && \
+  yum install -y python38 python38-devel && \
   yum clean all && \
   ln -s /usr/bin/python3.8 /usr/bin/python3 && \
   ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -7,7 +7,6 @@ RUN yum groupinstall -y development && \
   tar \
   gzip \
   unzip \
-  python3 \
   jq \
   grep \
   curl \
@@ -19,8 +18,18 @@ RUN yum groupinstall -y development && \
   libgmp3-dev \
   zlib1g-dev \
   libmpc-devel \
-  python3-devel \
-  && yum clean all
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python3.8 python3.8-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 RUN gem update --system --no-document
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Updates the Python 3.7 build images to install SAM CLI through the native installer instead of using `pip` and adds a Lambda Builders executable in the image.

Additionally, since Python 3.7 is being deprecated as an installation environment for SAM CLI, all of the images that build it from source needs their Python environment updated. The Python version that is provided in the stable package repo is 3.7. We'll need to install the extras repo to get Python 3.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
