### PR TITLE
fix: use native zip when installing sam cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+      - run: |
+          : install sam cli
+          wget https://github.com/aws/aws-sam-cli/releases/download/${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
+          unzip aws-sam-cli-linux-arm64.zip -d sam-installation
+          ./sam-installation/install
+          sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-single-arch
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
           unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          ./sam-installation/install --update
+          sudo ./sam-installation/install --update
           sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-single-arch
@@ -100,7 +100,7 @@ jobs:
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
           unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          ./sam-installation/install --update
+          sudo ./sam-installation/install --update
           sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-multi-arch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - run: |
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
-          unzip aws-sam-cli-linux-arm64.zip -d sam-installation
+          unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
           ./sam-installation/install
           sam --version
       - run: make init
@@ -99,7 +99,7 @@ jobs:
       - run: |
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
-          unzip aws-sam-cli-linux-arm64.zip -d sam-installation
+          unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
           ./sam-installation/install
           sam --version
       - run: make init

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
           unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          ./sam-installation/install
+          ./sam-installation/install --update
           sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-single-arch
@@ -100,7 +100,7 @@ jobs:
           : install sam cli
           wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
           unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          ./sam-installation/install
+          ./sam-installation/install --update
           sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-multi-arch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - run: |
-          : install sam cli
-          wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
-          unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          sudo ./sam-installation/install --update
-          sam --version
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-single-arch
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make test
@@ -96,12 +93,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - run: |
-          : install sam cli
-          wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
-          unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
-          sudo ./sam-installation/install --update
-          sam --version
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-multi-arch
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: "3.9"
       - run: |
           : install sam cli
-          wget https://github.com/aws/aws-sam-cli/releases/download/${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
+          wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
           unzip aws-sam-cli-linux-arm64.zip -d sam-installation
           ./sam-installation/install
           sam --version
@@ -96,6 +96,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+      - run: |
+          : install sam cli
+          wget https://github.com/aws/aws-sam-cli/releases/download/v${{needs.get-sam-cli-version.outputs.sam_cli_version}}/aws-sam-cli-linux-x86_64.zip
+          unzip aws-sam-cli-linux-arm64.zip -d sam-installation
+          ./sam-installation/install
+          sam --version
       - run: make init
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make build-multi-arch
       - run: SAM_CLI_VERSION=${{needs.get-sam-cli-version.outputs.sam_cli_version}} RUNTIME=${{matrix.runtime}} make test

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -25,6 +25,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "a
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
+ARG IMAGE_ARCH # need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -17,19 +17,7 @@ RUN yum groupinstall -y development && \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  libmpc-devel \
-  amazon-linux-extras
-
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  libmpc-devel
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -37,13 +25,19 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "a
 
 # Install SAM CLI in a dedicated Python virtualenv
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v${SAM_CLI_VERSION}.zip" -o ./samcli.zip && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r "./aws-sam-cli-${SAM_CLI_VERSION}/requirements/base.txt" && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install "./aws-sam-cli-${SAM_CLI_VERSION}" && \
-  rm ./samcli.zip && rm -rf "./aws-sam-cli-${SAM_CLI_VERSION}"
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -35,9 +35,10 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-ARG IMAGE_ARCH # need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
 RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -17,7 +17,19 @@ RUN yum groupinstall -y development && \
   procps \
   libgmp3-dev \
   zlib1g-dev \
-  libmpc-devel
+  libmpc-devel  \
+  amazon-linux-extras
+
+# Install extras so that Python 3.8 is installable
+# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+RUN amazon-linux-extras enable python3.8 && \
+  yum clean metadata && \
+  yum install -y python38 python38-devel && \
+  yum clean all && \
+  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+  python3 --version && \
+  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -41,15 +41,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm -rf awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v${SAM_CLI_VERSION}.zip" -o ./samcli.zip && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r "./aws-sam-cli-${SAM_CLI_VERSION}/requirements/base.txt" && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install "./aws-sam-cli-${SAM_CLI_VERSION}" && \
-  rm ./samcli.zip && rm -rf "./aws-sam-cli-${SAM_CLI_VERSION}"
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -35,15 +35,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -35,15 +35,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -28,15 +28,23 @@ RUN dnf groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -61,8 +61,6 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.or
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
 
-ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
-
 COPY ATTRIBUTION.txt /
 
 # Compatible with initial base image

--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -21,7 +21,6 @@ RUN yum groupinstall -y development && \
   liblzma-dev \
   libxslt-devel \
   libmpc-devel \
-  java-1.8.0-openjdk-devel \
   && yum clean all
 
 # Include build tools for the Function Build image.

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -38,15 +38,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs12x
+++ b/build-image-src/Dockerfile-nodejs12x
@@ -40,15 +40,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs14x
+++ b/build-image-src/Dockerfile-nodejs14x
@@ -40,15 +40,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -40,15 +40,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -40,15 +40,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -32,17 +32,23 @@ RUN dnf groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-# Nodejs20 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  LD_LIBRARY_PATH= /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  LD_LIBRARY_PATH= /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-develop
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -45,8 +45,10 @@ RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
+# Nodejs20 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
+# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -43,7 +43,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 # Nodejs20 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
 # Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -37,15 +37,23 @@ RUN amazon-linux-extras enable python3.8 && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -22,15 +22,23 @@ ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -26,15 +26,23 @@ RUN yum groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -26,15 +26,23 @@ RUN yum groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -27,15 +27,23 @@ RUN dnf groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -26,15 +26,23 @@ RUN yum groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -26,15 +26,23 @@ RUN yum groupinstall -y development && \
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-ruby27
+++ b/build-image-src/Dockerfile-ruby27
@@ -37,16 +37,23 @@ RUN gem update --system --no-document
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -37,16 +37,23 @@ RUN gem update --system --no-document
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
 
-# Install SAM CLI in a dedicated Python virtualenv
+# Install SAM CLI from native installer
 ARG SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
 
-RUN curl -L "https://github.com/awslabs/aws-sam-cli/archive/v$SAM_CLI_VERSION.zip" -o "samcli.zip" && \
-  unzip samcli.zip && python3 -m venv /usr/local/opt/sam-cli && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install -r ./aws-sam-cli-$SAM_CLI_VERSION/requirements/base.txt && \
-  /usr/local/opt/sam-cli/bin/pip3 --no-cache-dir install ./aws-sam-cli-$SAM_CLI_VERSION && \
-  rm samcli.zip && rm -rf aws-sam-cli-$SAM_CLI_VERSION
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
-ENV PATH=$PATH:/usr/local/opt/sam-cli/bin
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`

--- a/tests/apps/java8/sam-test-app/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/tests/apps/java8/sam-test-app/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -31,7 +31,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
             return response
                     .withStatusCode(200)
                     .withBody(output);
-        } catch (Exception e) {
+        } catch (IOException e) {
             return response
                     .withBody("{}")
                     .withStatusCode(500);

--- a/tests/apps/java8/sam-test-app/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/tests/apps/java8/sam-test-app/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -31,7 +31,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
             return response
                     .withStatusCode(200)
                     .withBody(output);
-        } catch (IOException e) {
+        } catch (Exception e) {
             return response
                     .withBody("{}")
                     .withStatusCode(500);

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -111,24 +111,23 @@ class BuildImageBase(TestCase):
                 environment=["LD_LIBRARY_PATH="]
             ).decode()
         else:
+            op = self.client.containers.run(
+                image=self.image,
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    sam_init + " && cd sam-app && sam build --debug",
+                ],
+            ).decode()
             if self.runtime == "java8":
                 op = self.client.containers.run(
-                    image=self.image,
-                    command=[
-                        "/bin/sh",
-                        "-c",
-                        sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
-                    ],
-                ).decode()
-            else:
-                op = self.client.containers.run(
-                    image=self.image,
-                    command=[
-                        "/bin/sh",
-                        "-c",
-                        sam_init + " && cd sam-app && sam build --debug",
-                    ],
-                ).decode()
+                image=self.image,
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
+                ],
+            ).decode()
         self.assertTrue(op.find("Build Succeeded"))
 
     def test_external_apps(self):

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -116,7 +116,16 @@ class BuildImageBase(TestCase):
                 command=[
                     "/bin/sh",
                     "-c",
-                    sam_init + " && cd sam-app && sam build",
+                    sam_init + " && cd sam-app && sam build --debug",
+                ],
+            ).decode()
+            if self.runtime == "java8":
+                op = self.client.containers.run(
+                image=self.image,
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
                 ],
             ).decode()
         self.assertTrue(op.find("Build Succeeded"))

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -116,16 +116,7 @@ class BuildImageBase(TestCase):
                 command=[
                     "/bin/sh",
                     "-c",
-                    sam_init + " && cd sam-app && sam build --debug",
-                ],
-            ).decode()
-            if self.runtime == "java8":
-                op = self.client.containers.run(
-                image=self.image,
-                command=[
-                    "/bin/sh",
-                    "-c",
-                    sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
+                    sam_init + " && cd sam-app && sam build",
                 ],
             ).decode()
         self.assertTrue(op.find("Build Succeeded"))

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -111,23 +111,24 @@ class BuildImageBase(TestCase):
                 environment=["LD_LIBRARY_PATH="]
             ).decode()
         else:
-            op = self.client.containers.run(
-                image=self.image,
-                command=[
-                    "/bin/sh",
-                    "-c",
-                    sam_init + " && cd sam-app && sam build --debug",
-                ],
-            ).decode()
             if self.runtime == "java8":
                 op = self.client.containers.run(
-                image=self.image,
-                command=[
-                    "/bin/sh",
-                    "-c",
-                    sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
-                ],
-            ).decode()
+                    image=self.image,
+                    command=[
+                        "/bin/sh",
+                        "-c",
+                        sam_init + " && cd sam-app && cd HelloWorldFunction && mvn clean install",
+                    ],
+                ).decode()
+            else:
+                op = self.client.containers.run(
+                    image=self.image,
+                    command=[
+                        "/bin/sh",
+                        "-c",
+                        sam_init + " && cd sam-app && sam build --debug",
+                    ],
+                ).decode()
         self.assertTrue(op.find("Build Succeeded"))
 
     def test_external_apps(self):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updates `Dockerfile` for each runtime to use Native AWS SAM CLI Linux distribution rather than using the `pip install`.

Also added couple of integration tests which runs 
- `sam init`
- `sam build -u -i {local_img_name}`
- `sam local invoke` 
to confirm latest build image is working as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
