### PR TITLE
fix: Use provided java instead of openjdk

### DIFF
--- a/build-image-src/Dockerfile-java8
+++ b/build-image-src/Dockerfile-java8
@@ -21,7 +21,6 @@ RUN yum groupinstall -y development && \
   liblzma-dev \
   libxslt-devel \
   libmpc-devel \
-  java-1.8.0-openjdk-devel \
   && yum clean all
 
 # Include build tools for the Function Build image.
@@ -62,7 +61,7 @@ RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.or
 
 ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
 
-ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-amazon-corretto"
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The development Java version we install changed the folder name of the installed Java version at some point. This is causing Lambda builders to fail, since it invokes Maven, and it is no longer able to find the correct Java via `JAVA_HOME`.

Updates this by removing the version we install, and matches `JAVA_HOME` to the one pre installed in the image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
