### PR TITLE
chore: bump  go version to 1.21.6

### DIFF
--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -25,7 +25,7 @@ RUN yum groupinstall -y development && \
   && yum clean all
 
 # Install Go
-RUN curl -L https://go.dev/dl/go1.20.linux-amd64.tar.gz | tar -zx -C /usr/local
+RUN curl -L https://go.dev/dl/go1.21.6.linux-amd64.tar.gz | tar -zx -C /usr/local
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 # Set GOPROXY envvar to avoid using the default proxy.golang.org proxy
 ENV GOPROXY=direct

--- a/build-image-src/Dockerfile-go1x
+++ b/build-image-src/Dockerfile-go1x
@@ -25,7 +25,7 @@ RUN yum groupinstall -y development && \
   && yum clean all
 
 # Install Go
-RUN curl -L https://go.dev/dl/go1.21.6.linux-amd64.tar.gz | tar -zx -C /usr/local
+RUN curl -L https://go.dev/dl/$(curl -L "https://go.dev/VERSION/?m=text" | grep go1.).linux-amd64.tar.gz | tar -zx -C /usr/local
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 # Set GOPROXY envvar to avoid using the default proxy.golang.org proxy
 ENV GOPROXY=direct

--- a/tests/apps/go1.x/hello-world/go.mod
+++ b/tests/apps/go1.x/hello-world/go.mod
@@ -1,5 +1,5 @@
-require github.com/aws/aws-lambda-go v1.36.1
+require github.com/aws/aws-lambda-go v1.45.0
 
 module hello-world
 
-go 1.20
+go 1.21.6

--- a/tests/apps/go1.x/hello-world/go.sum
+++ b/tests/apps/go1.x/hello-world/go.sum
@@ -1,6 +1,10 @@
-github.com/aws/aws-lambda-go v1.36.1 h1:CJxGkL9uKszIASRDxzcOcLX6juzTLoTKtCIgUGcTjTU=
-github.com/aws/aws-lambda-go v1.36.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
+github.com/aws/aws-lambda-go v1.45.0 h1:3xS35Dlc8ffmcwfcKTyqJGiMuL0UDvkQaVUrI5yHycI=
+github.com/aws/aws-lambda-go v1.45.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION

*Description of changes:*
Update to go 1.21.6 and lib update of go test app.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
