### PR TITLE
fix: skip dotnet8 arm64 related tests

### DIFF
--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -628,6 +628,12 @@ class TestBIDotNet8Arm(AL2023BasedBuildImageBase):
         """
         self.assertTrue(self.check_package_output("dotnet --version", "8"))
         self.assertTrue(self.is_package_present("dotnet"))
+    
+    def test_containerized_build(self):
+        pass
+    
+    def test_sam_init(self):
+        pass
 
 
 @pytest.mark.ruby32x86_64


### PR DESCRIPTION
*Issue #, if available:*

`test_containerized_build` and `test_sam_init` tests taking long time on x86 environment. Disabling them now until we switch using arm64 runners for arm64 images.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
