### PR TITLE
fix: Install git in the al2023 build image

### DIFF
--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -15,6 +15,7 @@ RUN dnf install -y tar\
   libxslt-devel \
   libmpc-devel \
   python3-devel \
+  git \
   && dnf clean all
 
 # Install AWS CLI


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sam-cli/issues/6635

*Description of changes:*
Some runtimes like Go require `git` to be installed to execute the build. Since `git` is no longer installed by default in al2023, we add it here to install in the build image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
