### PR TITLE
fix: Pin requests until docker package is updated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 #docker minor version updates can include breaking changes. Auto update micro version only.
+# TODO: lucashuy
+# revisit the docker pin when docker fixes the below request issue
 docker~=4.2.0
 pylint~=2.6.0
 urllib3<2
+# TODO: lucashuy
+# pin requests until https://github.com/docker/docker-py/issues/3256 is fixed
+requests<2.32
 
 # Test requirements
 pytest==7.3.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Newer version of `requests` was released that introduces a breaking change for `docker`. We need to pin `requests` until `docker` releases a new version, upon then we can remove the pins for both.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
