### PR TITLE
fix(tests): Unpin requests and bump docker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,8 @@
-#docker minor version updates can include breaking changes. Auto update micro version only.
-# TODO: lucashuy
-# revisit the docker pin when docker fixes the below request issue
-docker~=4.2.0
+# docker minor version updates can include breaking changes. Auto update micro version only.
+docker~=7.1.0
 pylint~=2.6.0
 urllib3<2
-# TODO: lucashuy
-# pin requests until https://github.com/docker/docker-py/issues/3256 is fixed
-requests<2.32
+requests~=2.31.0
 
 # Test requirements
 pytest==7.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 docker~=7.1.0
 pylint~=2.6.0
 urllib3<2
-requests~=2.31.0
+requests~=2.32.0
 
 # Test requirements
 pytest==7.3.1


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Now that there is a fix for the breaking requests change, we can use the newer versions. Additionally, this PR bumps `docker-py` to a newer version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
