### PR TITLE
chore: Skip use_containerized test temporarily

### DIFF
--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -162,7 +162,7 @@ class BuildImageBase(TestCase):
         # Skip this test for now as these checks are failing for x86
         # TODO: Add the checks back once the below docker issue is fixed
         # Error: 500 Server Error for : Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown")
-        if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS or self.tag == "x86_64:
+        if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS or self.tag == "x86_64":
             self.skipTest(f"Skipping for {self.runtime} and architecture: {self.tag}")
         init_args = [
             "sam",

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -159,8 +159,11 @@ class BuildImageBase(TestCase):
                 self.assertTrue(out.decode().find("Build Succeeded"))
 
     def test_containerized_build(self):
-        if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS:
-            self.skipTest(f"Skipping for {self.runtime}")
+        # Skip this test for now as these checks are failing for x86
+        # TODO: Add the checks back once the below docker issue is fixed
+        # Error: 500 Server Error for : Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown")
+        # if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS:
+        self.skipTest(f"Skipping for {self.runtime}")
         init_args = [
             "sam",
             "init",

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -162,8 +162,8 @@ class BuildImageBase(TestCase):
         # Skip this test for now as these checks are failing for x86
         # TODO: Add the checks back once the below docker issue is fixed
         # Error: 500 Server Error for : Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown")
-        # if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS:
-        self.skipTest(f"Skipping for {self.runtime}")
+        if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS or self.tag == "x86_64:
+            self.skipTest(f"Skipping for {self.runtime} and architecture: {self.tag}")
         init_args = [
             "sam",
             "init",


### PR DESCRIPTION
The containerized tests are failing due to the below error, but the test passes in GH actions. Skipping this test for now.

```
Error: 500 Server Error: Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
