### PR TITLE
feat: Add ruby3.4 runtime support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           - "python313"
           - "ruby32"
           - "ruby33"
+          - "ruby34"
         include:
           - skip_arm_test: false
           - runtime: "dotnet8"

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ IS_python312 := python3.12
 IS_python313 := python3.13
 IS_ruby32 := ruby3.2
 IS_ruby33 := ruby3.3
+IS_ruby34 := ruby3.4
 
 init:
 	pip install -Ur requirements.txt

--- a/build-image-src/ATTRIBUTION.txt
+++ b/build-image-src/ATTRIBUTION.txt
@@ -377,13 +377,11 @@ limitations under the License.
 
 ------
 
-** ruby; version 2.5.8 -- https://www.ruby-lang.org/
-Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
-** ruby; version 2.7.1 -- https://www.ruby-lang.org/
-Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
 ** ruby; version 3.2.1 -- https://www.ruby-lang.org/
 Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
 ** ruby; version 3.3.0 -- https://www.ruby-lang.org/
+Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
+** ruby; version 3.4.0 -- https://www.ruby-lang.org/
 Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.
 
 Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.

--- a/build-image-src/Dockerfile-ruby34
+++ b/build-image-src/Dockerfile-ruby34
@@ -1,0 +1,59 @@
+ARG IMAGE_ARCH
+FROM public.ecr.aws/lambda/ruby:3.4-$IMAGE_ARCH
+
+RUN dnf remove -y microdnf-dnf && \
+  microdnf install -y dnf
+
+RUN dnf groupinstall -y development && \
+  dnf install -y \
+  tar \
+  gzip \
+  unzip \
+  python3 \
+  jq \
+  grep \
+  make \
+  rsync \
+  binutils \
+  gcc-c++ \
+  procps \
+  gmp-devel \
+  zlib-devel \
+  libmpc-devel \
+  python3-devel \
+  libyaml-devel \
+  && dnf clean all
+
+# Install AWS CLI
+ARG AWS_CLI_ARCH
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws
+
+# Install SAM CLI from native installer
+ARG SAM_CLI_VERSION
+# need to redefine since ARG is not available after FROM tag: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG IMAGE_ARCH
+RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERSION/aws-sam-cli-linux-$IMAGE_ARCH.zip" -o "samcli.zip" && \
+  unzip samcli.zip -d sam-installation && ./sam-installation/install && \
+  rm samcli.zip && rm -rf sam-installation && sam --version
+
+# Prepare virtualenv for lambda builders
+RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+# Install lambda builders in a dedicated Python virtualenv
+RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/requirements/base.txt | grep aws_lambda_builders | cut -d= -f3) && \
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+
+ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
+
+ENV LANG=en_US.UTF-8
+
+# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
+# Python for it to be picked up during `sam build`
+RUN pip3 install wheel
+
+COPY ATTRIBUTION.txt /
+
+# Compatible with initial base image
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/build-image-src/build_all_images.sh
+++ b/build-image-src/build_all_images.sh
@@ -40,6 +40,7 @@ docker build -f Dockerfile-python312 -t amazon/aws-sam-cli-build-image-python3.1
 docker build -f Dockerfile-python313 -t amazon/aws-sam-cli-build-image-python3.13:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 . &
 docker build -f Dockerfile-ruby32 -t amazon/aws-sam-cli-build-image-ruby3.2:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 . &
 docker build -f Dockerfile-ruby33 -t amazon/aws-sam-cli-build-image-ruby3.3:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 . &
+docker build -f Dockerfile-ruby34 -t amazon/aws-sam-cli-build-image-ruby3.4:x86_64 --platform linux/amd64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=x86_64 --build-arg IMAGE_ARCH=x86_64 . &
 wait
 
 # Build arm64 images
@@ -65,4 +66,5 @@ docker build -f Dockerfile-python312 -t amazon/aws-sam-cli-build-image-python3.1
 docker build -f Dockerfile-python313 -t amazon/aws-sam-cli-build-image-python3.13:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 . &
 docker build -f Dockerfile-ruby32 -t amazon/aws-sam-cli-build-image-ruby3.2:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 . &
 docker build -f Dockerfile-ruby33 -t amazon/aws-sam-cli-build-image-ruby3.3:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 . &
+docker build -f Dockerfile-ruby34 -t amazon/aws-sam-cli-build-image-ruby3.4:arm64 --platform linux/arm64 --build-arg SAM_CLI_VERSION=$SAM_CLI_VERSION --build-arg AWS_CLI_ARCH=aarch64 --build-arg IMAGE_ARCH=arm64 . &
 wait

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,3 +23,4 @@ markers =
     python313
     ruby32
     ruby33
+    ruby34

--- a/tests/apps/ruby3.4/sam-test-app/sam-test-app/Gemfile
+++ b/tests/apps/ruby3.4/sam-test-app/sam-test-app/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "httparty"
+
+group :test do
+  gem "test-unit"
+  gem "mocha"
+end

--- a/tests/apps/ruby3.4/sam-test-app/sam-test-app/events/event.json
+++ b/tests/apps/ruby3.4/sam-test-app/sam-test-app/events/event.json
@@ -1,0 +1,62 @@
+{
+  "body": "{\"message\": \"hello world\"}",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": false,
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/tests/apps/ruby3.4/sam-test-app/sam-test-app/hello_world/Gemfile
+++ b/tests/apps/ruby3.4/sam-test-app/sam-test-app/hello_world/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "httparty"
+
+ruby '~> 3.4.0'

--- a/tests/apps/ruby3.4/sam-test-app/sam-test-app/hello_world/app.rb
+++ b/tests/apps/ruby3.4/sam-test-app/sam-test-app/hello_world/app.rb
@@ -1,0 +1,38 @@
+# require 'httparty'
+require 'json'
+
+def lambda_handler(event:, context:)
+  # Sample pure Lambda function
+
+  # Parameters
+  # ----------
+  # event: Hash, required
+  #     API Gateway Lambda Proxy Input Format
+  #     Event doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
+
+  # context: object, required
+  #     Lambda Context runtime methods and attributes
+  #     Context doc: https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html
+
+  # Returns
+  # ------
+  # API Gateway Lambda Proxy Output Format: dict
+  #     'statusCode' and 'body' are required
+  #     # api-gateway-simple-proxy-for-lambda-output-format
+  #     Return doc: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+
+  # begin
+  #   response = HTTParty.get('http://checkip.amazonaws.com/')
+  # rescue HTTParty::Error => error
+  #   puts error.inspect
+  #   raise error
+  # end
+
+  {
+    statusCode: 200,
+    body: {
+      message: "Hello World!",
+      # location: response.body
+    }.to_json
+  }
+end

--- a/tests/apps/ruby3.4/sam-test-app/sam-test-app/template.yaml
+++ b/tests/apps/ruby3.4/sam-test-app/sam-test-app/template.yaml
@@ -1,0 +1,39 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  sam-test-app11
+
+  Sample SAM Template for sam-test-app11
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+Globals:
+  Function:
+    Timeout: 3
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+    Properties:
+      CodeUri: hello_world/
+      Handler: app.lambda_handler
+      Runtime: ruby3.4
+      Events:
+        HelloWorld:
+          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+          Properties:
+            Path: /hello
+            Method: get
+
+Outputs:
+  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+  # Find out more about other implicit resources you can reference within SAM
+  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+  HelloWorldApi:
+    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
+  HelloWorldFunction:
+    Description: "Hello World Lambda Function ARN"
+    Value: !GetAtt HelloWorldFunction.Arn
+  HelloWorldFunctionIamRole:
+    Description: "Implicit IAM Role created for Hello World function"
+    Value: !GetAtt HelloWorldFunctionRole.Arn

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -2,10 +2,10 @@ from unittest import TestCase
 from pathlib import Path
 import os
 import tarfile
-import docker  # type: ignore
-import pytest
 import tempfile
 import subprocess
+import docker  # type: ignore
+import pytest
 
 
 # These are the runtimes which doesn't have hello-world template, skipping them
@@ -159,9 +159,12 @@ class BuildImageBase(TestCase):
                 self.assertTrue(out.decode().find("Build Succeeded"))
 
     def test_containerized_build(self):
+        """
+        Test containerized build
+        """
         # Skip this test for now as these checks are failing for x86
         # TODO: Add the checks back once the below docker issue is fixed
-        # Error: 500 Server Error for : Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown")
+        # Error: 500 Server Error for : Internal Server Error ("failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown") # pylint: disable=line-too-long
         if self.runtime in SKIP_CONTAINERIZED_BUILD_TESTS or self.tag == "x86_64":
             self.skipTest(f"Skipping for {self.runtime} and architecture: {self.tag}")
         init_args = [
@@ -185,16 +188,16 @@ class BuildImageBase(TestCase):
             build_args += ["--mount-with", "WRITE"]
         invoke_args = ["sam", "local", "invoke", "HelloWorldFunction"]
         with tempfile.TemporaryDirectory() as tmpdir:
-            init_result = subprocess.run(init_args, cwd=tmpdir)
+            init_result = subprocess.run(init_args, cwd=tmpdir, check=True)
             self.assertEqual(init_result.returncode, 0)
 
             build_result = subprocess.run(
-                build_args, cwd=os.path.join(tmpdir, "sam-app")
+                build_args, cwd=os.path.join(tmpdir, "sam-app"), check=True
             )
             self.assertEqual(build_result.returncode, 0)
 
             invoke_result = subprocess.run(
-                invoke_args, cwd=os.path.join(tmpdir, "sam-app")
+                invoke_args, cwd=os.path.join(tmpdir, "sam-app"), check=True
             )
             self.assertEqual(invoke_result.returncode, 0)
 

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -161,6 +161,7 @@ class TestBIJava17AL2ForArmGradle(BuildImageBase):
         self.assertTrue(self.is_package_present("gradle"))
         self.assertTrue(self.is_architecture("aarch64"))
 
+
 @pytest.mark.java21x86_64
 class TestBIJava21Maven(AL2023BasedBuildImageBase):
     __test__ = True
@@ -308,6 +309,7 @@ class TestBINode18ForArm(BuildImageBase):
         self.assertTrue(self.is_package_present("npm"))
         self.assertTrue(self.is_architecture("aarch64"))
 
+
 @pytest.mark.nodejs20xx86_64
 class TestBINode20(AL2023BasedBuildImageBase):
     __test__ = True
@@ -340,6 +342,7 @@ class TestBINode20ForArm(AL2023BasedBuildImageBase):
         self.assertTrue(self.check_package_output("node --version", "v20."))
         self.assertTrue(self.is_package_present("npm"))
         self.assertTrue(self.is_architecture("aarch64"))
+
 
 @pytest.mark.nodejs22xx86_64
 class TestBINode22(AL2023BasedBuildImageBase):
@@ -456,6 +459,7 @@ class TestBIPython310(BuildImageBase):
         self.assertTrue(self.check_package_output("python --version", "Python 3.10."))
         self.assertTrue(self.is_package_present("pip"))
 
+
 @pytest.mark.python311arm64
 class TestBIPython311ForArm(BuildImageBase):
     __test__ = True
@@ -487,6 +491,7 @@ class TestBIPython311(BuildImageBase):
         self.assertTrue(self.check_package_output("python --version", "Python 3.11."))
         self.assertTrue(self.is_package_present("pip"))
 
+
 @pytest.mark.python312arm64
 class TestBIPython312ForArm(AL2023BasedBuildImageBase):
     __test__ = True
@@ -517,6 +522,7 @@ class TestBIPython312(AL2023BasedBuildImageBase):
         """
         self.assertTrue(self.check_package_output("python --version", "Python 3.12."))
         self.assertTrue(self.is_package_present("pip"))
+
 
 @pytest.mark.python313arm64
 class TestBIPython313ForArm(AL2023BasedBuildImageBase):
@@ -691,6 +697,7 @@ class TestBIRuby32(BuildImageBase):
         self.assertTrue(self.is_package_present("gem"))
         self.assertTrue(self.is_architecture("x86_64"))
 
+
 @pytest.mark.ruby32arm64
 class TestBIRuby32ForArm(BuildImageBase):
     __test__ = True
@@ -726,6 +733,7 @@ class TestBIRuby33(AL2023BasedBuildImageBase):
         self.assertTrue(self.is_package_present("gem"))
         self.assertTrue(self.is_architecture("x86_64"))
 
+
 @pytest.mark.ruby33arm64
 class TestBIRuby33ForArm(AL2023BasedBuildImageBase):
     __test__ = True
@@ -742,6 +750,43 @@ class TestBIRuby33ForArm(AL2023BasedBuildImageBase):
         self.assertTrue(self.is_package_present("bundler"))
         self.assertTrue(self.is_package_present("gem"))
         self.assertTrue(self.is_architecture("aarch64"))
+
+
+@pytest.mark.ruby34x86_64
+class TestBIRuby34(AL2023BasedBuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("ruby3.4", "Dockerfile-ruby34", "bundler", tag="x86_64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("ruby --version", "ruby 3.4."))
+        self.assertTrue(self.is_package_present("bundler"))
+        self.assertTrue(self.is_package_present("gem"))
+        self.assertTrue(self.is_architecture("x86_64"))
+
+
+@pytest.mark.ruby34arm64
+class TestBIRuby34ForArm(AL2023BasedBuildImageBase):
+    __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass("ruby3.4", "Dockerfile-ruby34", "bundler", tag="arm64")
+
+    def test_packages(self):
+        """
+        Test packages specific to this build image
+        """
+        self.assertTrue(self.check_package_output("ruby --version", "ruby 3.4."))
+        self.assertTrue(self.is_package_present("bundler"))
+        self.assertTrue(self.is_package_present("gem"))
+        self.assertTrue(self.is_architecture("aarch64"))
+
 
 @pytest.mark.provided_al2x86_64
 class TestBIProvidedAL2(BuildImageBase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ruby 3.4 is coming soon: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-future

The changes look pretty much the same as the ones that were added [for Ruby 3.3](https://github.com/aws/aws-sam-build-images/pull/138/files)

I fixed some pylint errors in `tests/build_image_base_test.py` too that were causing `make pr` to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
