### PR TITLE
chore: Upgrade version of Maven in older Java runtimes

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -67,10 +67,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -67,10 +67,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-7.3.1-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -59,10 +59,10 @@ ENV JAVA_HOME="/var/lang"
 # Install Java build tools
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-8.4-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-8.4/bin:/usr/local/maven/apache-maven-3.9.5/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-8.4/bin:/usr/local/maven/apache-maven-3.9.10/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -69,10 +69,10 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.8/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
*Issue #, if available:*

The build image build is failing because Maven 3.8.8 URL isn't available anymore. So we move to use 3.8.9 in these older Java versions. (Java 21 uses Maven 3.9)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
