### PR TITLE
chore(test): Add scheduled workflow to run build tests on Tuesdays and Thursdays

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build & Test
 
 on:
+  schedule:
+    # Run every Tuesday and Thursday at 6:00 AM UTC
+    - cron: '0 6 * * 2,4'
   pull_request:
     branches:
       - develop
@@ -72,6 +75,8 @@ jobs:
     needs: [get-sam-cli-version]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"


### PR DESCRIPTION
## Summary
This PR adds a scheduled workflow trigger to run build tests automatically on Tuesdays and Thursdays at 6:00 AM UTC.

## Changes
- Added cron schedule \`0 6 * * 2,4\` to run every Tuesday and Thursday at 6:00 AM UTC
- Configured scheduled runs to specifically test the develop branch
- Maintains existing PR and merge group triggers

## Benefits
- Provides regular automated testing of the develop branch
- Helps catch issues early with scheduled builds
- Ensures build images remain functional across all supported runtimes

## Testing
The workflow will trigger automatically on the next Tuesday/Thursday, or can be manually triggered for testing." --base develop

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.