### PR TITLE
fix: revert gradle from 9.0.0 to 8.4 in Dockerfile-java21

### DIFF
--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -57,12 +57,12 @@ RUN pip3 install wheel
 ENV JAVA_HOME="/var/lang"
 
 # Install Java build tools
-RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-9.0.0-bin.zip && \
+RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-8.4-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
   curl -L https://downloads.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-9.0.0/bin:/usr/local/maven/apache-maven-3.9.11/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-8.4/bin:/usr/local/maven/apache-maven-3.9.11/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
Docker java21 build start seeing compatibility issue with gradle 9.0.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
