### PR TITLE
Python build images: install setuptools only; remove wheel

### DIFF
--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -46,9 +46,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -46,9 +46,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -47,9 +47,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel setuptools
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -47,9 +47,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel setuptools
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -46,9 +46,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -46,9 +46,8 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 ENV LANG=en_US.UTF-8
 
-# Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
-# Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+# Install setuptools so that Python packages with build requirements can be compiled during `sam build`
+RUN pip3 install setuptools
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

### 🔄 What Changed

* Updated all Python build images:

  * Replaced

    ```dockerfile
    pip3 install wheel setuptools
    ```

    with

    ```dockerfile
    pip3 install setuptools
    ```

---

### 📝 Why

* Fixes: **Bug #153**
* Rationale:

  * `wheel` as a standalone package is no longer required:

    * The `bdist_wheel` command has been moved to **setuptools ≥ 70.1**.
    * `setuptools` vendors the wheel functionality (`setuptools/_vendor/wheel`).
    * Pip injects `wheel` only for older setuptools builds.

**References:**

* [wheel/bdist_wheel.py](https://github.com/pypa/wheel/blob/0.45.1/src/wheel/bdist_wheel.py) – deprecation warning about `bdist_wheel`.
* [setuptools/command/bdist_wheel.py](https://github.com/pypa/setuptools/blob/v80.9.0/setuptools/command/bdist_wheel.py) – new canonical implementation.
* [setuptools/_vendor/wheel/bdist_wheel.py](https://github.com/pypa/setuptools/blob/v80.9.0/setuptools/_vendor/wheel/bdist_wheel.py) – vendored copy for compatibility.

---

### ✅ Verification

* Built images:

  * `amazon/aws-sam-cli-build-image-python3.12:x86_64` (SAM CLI 1.144.0)
  * `amazon/aws-sam-cli-build-image-python3.13:x86_64` (SAM CLI 1.144.0)
* Tests:

  * `pytest` runtime tests (3.12) → Passed.
  * Manual builds inside both images:

    * `aiohttp@v3.11.11` via `requirements.txt` → ✅ succeeded.
    * `cryptography==43.0.1` → ✅ succeeded.
* Outcome: Removing `wheel` and ensuring `setuptools` resolves the failure and supports packages requiring wheel builds and VCS installs.

---

### 📊 Impact

* Removes unnecessary system package (`wheel`).
* Keeps images aligned with modern Python packaging practices.
* No regressions observed in functional and package build tests.

---

### 🚀 How to Reproduce

1. Build images:

   ```bash
   SAM_CLI_VERSION=1.144.0 RUNTIME=python312 make build-x86_64-arch
   SAM_CLI_VERSION=1.144.0 RUNTIME=python313 make build-x86_64-arch
   ```
2. Inside container, run `sam build` with a temp app requiring:

   * `cryptography==43.0.1`
   * `git+https://github.com/aio-libs/aiohttp.git@v3.11.11`
3. Both builds should succeed without installing `wheel` system-wide.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.