### PR TITLE
fix: don't upgrade RubyGems in Ruby3.2

### DIFF
--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -32,8 +32,6 @@ RUN amazon-linux-extras enable python3.8 && \
   python3 --version && \
   pip3 --version
 
-RUN gem update --system --no-document
-
 # Install AWS CLI
 ARG AWS_CLI_ARCH
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$AWS_CLI_ARCH.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip && rm -rf ./aws


### PR DESCRIPTION
Other Ruby versions are not updating RubyGems from what comes from the Lambda base image.

The upgrade is causing an issue with the just released 4.0.0 where the `--without` flag has been removed. That flag is used by Lambda Builders to build Ruby projects, so updating breaks that flow.

This needs to be fixed in Lambda Builders before updating the version of RubyGems anyway. For now we're good because the base image hasn't updated to the latest version.

**Issue #, if available:**

This following error happens when trying to use `sam build` inside a container with RubyGems 4.0.0, because the version of `bundler` deprecates the usage of `--without`, which is [used by Lambda Builders](https://github.com/aws/aws-lambda-builders/blob/1d369d34c546297d57b4c416dad209a45517f728/aws_lambda_builders/workflows/ruby_bundler/actions.py#L31) 
```
Error: RubyBundlerBuilder:RubyBundle - Bundler Failed: The `--without` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set without 'development test'`, and stop using this flag
```


**Description of changes:**

Keep the version of RubyGems coming from the Lambda base image, like the images for Ruby3.3 and 3.4. 

Lambda Builders needs to fix the usage of `--without` before upgrading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
