### PR TITLE
fix(test): run dotnet10 tests with `--mount-with WRITE` option

### DIFF
--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -19,7 +19,7 @@ SKIP_CONTAINERIZED_BUILD_TESTS = {
 }
 # These are the runtimes which requires `--mount-with WRITE` option to build functions
 # in a containerized build
-MOUNT_WITH_WRITE_RUNTIMES = {"dotnet6", "dotnet8"}
+MOUNT_WITH_WRITE_RUNTIMES = {"dotnet6", "dotnet8", "dotnet10"}
 # Specific runtime+dep_manager+tag combinations that require write permissions
 # Format: (runtime, dep_manager, tag)
 MOUNT_WITH_WRITE_COMBINATIONS = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

run dotnet10 tests with `--mount-with WRITE` option

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
