### PR TITLE
fix: pin wheel to version 0.45.1

### DIFF
--- a/build-image-src/Dockerfile-dotnet10
+++ b/build-image-src/Dockerfile-dotnet10
@@ -55,7 +55,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -57,7 +57,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -63,7 +63,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet8
+++ b/build-image-src/Dockerfile-dotnet8
@@ -55,7 +55,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet9
+++ b/build-image-src/Dockerfile-dotnet9
@@ -55,7 +55,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -57,7 +57,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -57,7 +57,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -50,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -50,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -60,7 +60,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 # Setup Java Home
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -62,7 +62,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -62,7 +62,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -56,7 +56,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel
+RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -56,7 +56,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel
+RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -56,7 +56,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel
+RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -66,7 +66,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -52,7 +52,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -48,7 +48,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -48,7 +48,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -49,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel setuptools
+RUN pip3 install wheel==0.45.1 setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -49,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel setuptools
+RUN pip3 install wheel==0.45.1 setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python314
+++ b/build-image-src/Dockerfile-python314
@@ -49,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel setuptools
+RUN pip3 install wheel==0.45.1 setuptools
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -48,7 +48,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -48,7 +48,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -56,7 +56,7 @@ ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-ruby33
+++ b/build-image-src/Dockerfile-ruby33
@@ -50,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-ruby34
+++ b/build-image-src/Dockerfile-ruby34
@@ -50,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
### Issue, if available:
While building images, we get error:
```
 > [10/11] RUN pip3 install wheel:
0.406 Collecting wheel
0.425   Downloading wheel-0.46.3-py3-none-any.whl (30 kB)
0.477 Collecting packaging>=24.0
0.481   Downloading packaging-26.0-py3-none-any.whl (74 kB)
0.501 Installing collected packages: packaging, wheel
0.501   Attempting uninstall: packaging
0.501     Found existing installation: packaging 21.3
0.502 ERROR: Cannot uninstall packaging 21.3, RECORD file not found. Hint: The package was installed by rpm.
```

### Description of changes:
Pinning "wheel" package to version 0.45.1 to avoid compatibility issues with the "packaging" package present in the latest wheel release. This is a temporary fix and should be updated to use the latest version once the upstream issue is resolved.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
