### PR TITLE
fix: disable library path for node 20-24 images

### DIFF
--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -6,11 +6,11 @@ ENV PATH=/var/lang/bin:$PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs20.x \
   NODE_PATH=/opt/nodejs/node20/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN dnf remove -y microdnf-dnf && \
-  microdnf install -y dnf
+RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
+  LD_LIBRARY_PATH= microdnf install -y dnf
 
-RUN dnf groupinstall -y development && \
-  dnf install -y \
+RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
+  LD_LIBRARY_PATH= dnf install -y \
   tar \
   gzip \
   unzip \
@@ -27,8 +27,8 @@ RUN dnf groupinstall -y development && \
   libmpc-devel \
   python3-devel \
   && dnf clean all
-  
-RUN dnf upgrade -y --releasever=latest
+
+RUN LD_LIBRARY_PATH= dnf upgrade -y --releasever=latest
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -2,15 +2,14 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:20-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs20.x \
   NODE_PATH=/opt/nodejs/node20/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
-  LD_LIBRARY_PATH= microdnf install -y dnf
+RUN dnf remove -y microdnf-dnf && \
+  microdnf install -y dnf
 
-RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
-  LD_LIBRARY_PATH= dnf install -y \
+RUN dnf groupinstall -y development && \
+  dnf install -y \
   tar \
   gzip \
   unzip \
@@ -28,7 +27,7 @@ RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
   python3-devel \
   && dnf clean all
 
-RUN LD_LIBRARY_PATH= dnf upgrade -y --releasever=latest
+RUN dnf upgrade -y --releasever=latest
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,12 +44,10 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs20 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -58,9 +55,17 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
+
+# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
+# with system Python/OpenSSL during package installation steps above.
+# Node uses a different version of OpenSSL than the system Python, which
+# causes an ImportError when Python tries to use the ssl/hashlib modules.
+# By deferring LD_LIBRARY_PATH until after all package installations, we
+# ensure dnf/pip/python pick up the correct system OpenSSL.
+ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -2,7 +2,6 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:20-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs20.x \
   NODE_PATH=/opt/nodejs/node20/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
@@ -59,14 +58,6 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
-
-# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
-# with system Python/OpenSSL during package installation steps above.
-# Node uses a different version of OpenSSL than the system Python, which
-# causes an ImportError when Python tries to use the ssl/hashlib modules.
-# By deferring LD_LIBRARY_PATH until after all package installations, we
-# ensure dnf/pip/python pick up the correct system OpenSSL.
-ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -2,6 +2,7 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:20-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
+  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs20.x \
   NODE_PATH=/opt/nodejs/node20/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -6,11 +6,11 @@ ENV PATH=/var/lang/bin:$PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs22.x \
   NODE_PATH=/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN dnf remove -y microdnf-dnf && \
-  microdnf install -y dnf
+RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
+  LD_LIBRARY_PATH= microdnf install -y dnf
 
-RUN dnf groupinstall -y development && \
-  dnf install -y \
+RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
+  LD_LIBRARY_PATH= dnf install -y \
   tar \
   gzip \
   unzip \
@@ -28,7 +28,7 @@ RUN dnf groupinstall -y development && \
   python3-devel \
   && dnf clean all
 
-RUN dnf upgrade -y --releasever=latest
+RUN LD_LIBRARY_PATH= dnf upgrade -y --releasever=latest
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -2,15 +2,14 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:22-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs22.x \
   NODE_PATH=/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
-  LD_LIBRARY_PATH= microdnf install -y dnf
+RUN dnf remove -y microdnf-dnf && \
+  microdnf install -y dnf
 
-RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
-  LD_LIBRARY_PATH= dnf install -y \
+RUN dnf groupinstall -y development && \
+  dnf install -y \
   tar \
   gzip \
   unzip \
@@ -28,7 +27,7 @@ RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
   python3-devel \
   && dnf clean all
 
-RUN LD_LIBRARY_PATH= dnf upgrade -y --releasever=latest
+RUN dnf upgrade -y --releasever=latest
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,12 +44,10 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs22 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -58,9 +55,17 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
+
+# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
+# with system Python/OpenSSL during package installation steps above.
+# Node uses a different version of OpenSSL than the system Python, which
+# causes an ImportError when Python tries to use the ssl/hashlib modules.
+# By deferring LD_LIBRARY_PATH until after all package installations, we
+# ensure dnf/pip/python pick up the correct system OpenSSL.
+ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -2,7 +2,6 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:22-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs22.x \
   NODE_PATH=/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
@@ -59,14 +58,6 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
-
-# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
-# with system Python/OpenSSL during package installation steps above.
-# Node uses a different version of OpenSSL than the system Python, which
-# causes an ImportError when Python tries to use the ssl/hashlib modules.
-# By deferring LD_LIBRARY_PATH until after all package installations, we
-# ensure dnf/pip/python pick up the correct system OpenSSL.
-ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -2,6 +2,7 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:22-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
+  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs22.x \
   NODE_PATH=/opt/nodejs/node22/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -2,7 +2,6 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:24-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs24.x \
   NODE_PATH=/opt/nodejs/node24/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
@@ -57,14 +56,6 @@ ENV LANG=en_US.UTF-8
 RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
-
-# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
-# with system Python/OpenSSL during package installation steps above.
-# Node uses a different version of OpenSSL than the system Python, which
-# causes an ImportError when Python tries to use the ssl/hashlib modules.
-# By deferring LD_LIBRARY_PATH until after all package installations, we
-# ensure dnf/pip/python pick up the correct system OpenSSL.
-ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -6,11 +6,11 @@ ENV PATH=/var/lang/bin:$PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs24.x \
   NODE_PATH=/opt/nodejs/node24/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN dnf remove -y microdnf-dnf && \
-  microdnf install -y dnf
+RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
+  LD_LIBRARY_PATH= microdnf install -y dnf
 
-RUN dnf groupinstall -y development && \
-  dnf install -y \
+RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
+  LD_LIBRARY_PATH= dnf install -y \
   tar \
   gzip \
   unzip \

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -2,6 +2,7 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:24-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
+  LD_LIBRARY_PATH= \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs24.x \
   NODE_PATH=/opt/nodejs/node24/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -2,15 +2,14 @@ ARG IMAGE_ARCH
 FROM public.ecr.aws/lambda/nodejs:24-$IMAGE_ARCH
 
 ENV PATH=/var/lang/bin:$PATH \
-  LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH \
   AWS_EXECUTION_ENV=AWS_Lambda_nodejs24.x \
   NODE_PATH=/opt/nodejs/node24/node_modules:/opt/nodejs/node_modules:/var/runtime/node_modules
 
-RUN LD_LIBRARY_PATH= dnf remove -y microdnf-dnf && \
-  LD_LIBRARY_PATH= microdnf install -y dnf
+RUN dnf remove -y microdnf-dnf && \
+  microdnf install -y dnf
 
-RUN LD_LIBRARY_PATH= dnf groupinstall -y development && \
-  LD_LIBRARY_PATH= dnf install -y \
+RUN dnf groupinstall -y development && \
+  dnf install -y \
   tar \
   gzip \
   unzip \
@@ -43,12 +42,10 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs22 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -56,9 +53,17 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN pip3 install wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
+
+# Set LD_LIBRARY_PATH for the Node.js runtime at the end to avoid conflicts
+# with system Python/OpenSSL during package installation steps above.
+# Node uses a different version of OpenSSL than the system Python, which
+# causes an ImportError when Python tries to use the ssl/hashlib modules.
+# By deferring LD_LIBRARY_PATH until after all package installations, we
+# ensure dnf/pip/python pick up the correct system OpenSSL.
+ENV LD_LIBRARY_PATH=/var/lang/lib:$LD_LIBRARY_PATH
 
 # Compatible with initial base image
 ENTRYPOINT []


### PR DESCRIPTION
*Issue #, if available:*
#189 is the PR where we first started seeing failures for node build images.

*Description of changes:*
It seems like there was a recent update to the Nodejs images using AL2023 that is causing build failures for Node 20, 22, and 24. The issue is that the `dnf install` that's being run when building the image from the Dockerfile is failing because it cannot find `OPENSSL_3.4.0`. This is actually an issue we experience in another place in the Dockerfiles, and have a workaround for it:
https://github.com/aws/aws-sam-build-images/blob/f11394df4f37167e8c2ed9778ac25a6b1ec7e34b/build-image-src/Dockerfile-nodejs20x?plain=1#L49-L53

This change makes it so the environment variable that had been interfering with Python and `dnf` is unset. For now, I'm not sure if I we should make this change considering it's unsetting a value that's explicitly in the base image, even if it is working.


[Example of the failed run here](https://github.com/aws/aws-sam-build-images/actions/runs/24678677442/job/72544862484?pr=189):
```
#7 [ 3/12] RUN dnf groupinstall -y development &&   dnf install -y   tar   gzip   unzip   python3   jq   grep   make   rsync   binutils   gcc-c++   procps   gmp-devel   zlib-devel   libmpc-devel   python3-devel   && dnf clean all
#7 0.157 Traceback (most recent call last):
#7 0.157   File "/usr/lib64/python3.9/random.py", line 61, in <module>
#7 0.157     from _sha512 import sha512 as _sha512
#7 0.157 ModuleNotFoundError: No module named '_sha512'
#7 0.157 
#7 0.157 During handling of the above exception, another exception occurred:
#7 0.157 
#7 0.157 Traceback (most recent call last):
#7 0.157   File "/usr/bin/dnf", line 61, in <module>
#7 0.157     from dnf.cli import main
#7 0.157   File "/usr/lib/python3.9/site-packages/dnf/__init__.py", line 23, in <module>
#7 0.157     import dnf.pycomp
#7 0.157   File "/usr/lib/python3.9/site-packages/dnf/pycomp.py", line 24, in <module>
#7 0.157     import email.mime.text
#7 0.157   File "/usr/lib64/python3.9/email/mime/text.py", line 10, in <module>
#7 0.157     from email.mime.nonmultipart import MIMENonMultipart
#7 0.157   File "/usr/lib64/python3.9/email/mime/nonmultipart.py", line 10, in <module>
#7 0.157     from email.mime.base import MIMEBase
#7 0.157   File "/usr/lib64/python3.9/email/mime/base.py", line 9, in <module>
#7 0.157     import email.policy
#7 0.157   File "/usr/lib64/python3.9/email/policy.py", line 7, in <module>
#7 0.157     from email._policybase import Policy, Compat32, compat32, _extend_docstrings
#7 0.157   File "/usr/lib64/python3.9/email/_policybase.py", line 9, in <module>
#7 0.157     from email.utils import _has_surrogates
#7 0.157   File "/usr/lib64/python3.9/email/utils.py", line 28, in <module>
#7 0.158     import random
#7 0.158   File "/usr/lib64/python3.9/random.py", line 64, in <module>
#7 0.158     from hashlib import sha512 as _sha512
#7 0.158   File "/usr/lib64/python3.9/hashlib.py", line 77, in <module>
#7 0.158     import _hashlib
#7 0.158 ImportError: /var/lang/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/lib64/python3.9/lib-dynload/_hashlib.cpython-39-x86_64-linux-gnu.so)
#7 ERROR: process "/bin/sh -c dnf groupinstall -y development &&   dnf install -y   tar   gzip   unzip   python3   jq   grep   make   rsync   binutils   gcc-c++   procps   gmp-devel   zlib-devel   libmpc-devel   python3-devel   && dnf clean all" did not complete successfully: exit code: 1
------
 > [ 3/12] RUN dnf groupinstall -y development &&   dnf install -y   tar   gzip   unzip   python3   jq   grep   make   rsync   binutils   gcc-c++   procps   gmp-devel   zlib-devel   libmpc-devel   python3-devel   && dnf clean all:
0.157     from email._policybase import Policy, Compat32, compat32, _extend_docstrings
0.157   File "/usr/lib64/python3.9/email/_policybase.py", line 9, in <module>
0.157     from email.utils import _has_surrogates
0.157   File "/usr/lib64/python3.9/email/utils.py", line 28, in <module>
0.158     import random
0.158   File "/usr/lib64/python3.9/random.py", line 64, in <module>
0.158     from hashlib import sha512 as _sha512
0.158   File "/usr/lib64/python3.9/hashlib.py", line 77, in <module>
0.158     import _hashlib
0.158 ImportError: /var/lang/lib/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/lib64/python3.9/lib-dynload/_hashlib.cpython-39-x86_64-linux-gnu.so)
------
Dockerfile-nodejs20x:12
--------------------
  11 |     
  12 | >>> RUN dnf groupinstall -y development && \
  13 | >>>   dnf install -y \
  14 | >>>   tar \
  15 | >>>   gzip \
  16 | >>>   unzip \
  17 | >>>   python3 \
  18 | >>>   jq \
  19 | >>>   grep \
  20 | >>>   make \
  21 | >>>   rsync \
  22 | >>>   binutils \
  23 | >>>   gcc-c++ \
  24 | >>>   procps \
  25 | >>>   gmp-devel \
  26 | >>>   zlib-devel \
  27 | >>>   libmpc-devel \
  28 | >>>   python3-devel \
  29 | >>>   && dnf clean all
  30 |       
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c dnf groupinstall -y development &&   dnf install -y   tar   gzip   unzip   python3   jq   grep   make   rsync   binutils   gcc-c++   procps   gmp-devel   zlib-devel   libmpc-devel   python3-devel   && dnf clean all" did not complete successfully: exit code: 1
make: *** [Makefile:58: build-multi-arch] Error 1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
