### PR TITLE
fix: update lambda-builders environment to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true

--- a/build-image-src/Dockerfile-dotnet10
+++ b/build-image-src/Dockerfile-dotnet10
@@ -22,6 +22,8 @@ RUN dnf groupinstall -y development && \
   gmp-devel \
   zlib-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   clang krb5-devel \
   openssl-devel \
   llvm \
@@ -42,7 +44,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -20,16 +20,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel  \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,7 +43,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -26,16 +26,14 @@ RUN yum groupinstall -y development && \
 
 RUN yum remove -y python3 python3-devel
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -51,7 +49,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-dotnet8
+++ b/build-image-src/Dockerfile-dotnet8
@@ -22,6 +22,8 @@ RUN dnf groupinstall -y development && \
   gmp-devel \
   zlib-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   clang krb5-devel \
   openssl-devel \
   llvm \
@@ -44,7 +46,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-dotnet9
+++ b/build-image-src/Dockerfile-dotnet9
@@ -22,6 +22,8 @@ RUN dnf groupinstall -y development && \
   gmp-devel \
   zlib-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   clang krb5-devel \
   openssl-devel \
   llvm \
@@ -44,7 +46,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -20,16 +20,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,7 +43,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -20,16 +20,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,7 +43,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -22,6 +22,8 @@ RUN dnf groupinstall -y development && \
   gmp-devel \
   zlib-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 RUN dnf upgrade -y --releasever=latest
@@ -39,7 +41,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -22,6 +22,8 @@ RUN dnf groupinstall -y development && \
   gmp-devel \
   zlib-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 # Install AWS CLI
@@ -37,7 +39,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -23,16 +23,14 @@ RUN yum groupinstall -y development && \
   amazon-linux-extras \
   java-1.8.0-openjdk-devel
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -48,7 +46,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -25,16 +25,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -50,7 +48,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -25,16 +25,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -50,7 +48,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -26,6 +26,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
   
 RUN dnf upgrade -y --releasever=latest
@@ -43,7 +45,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -26,6 +26,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 RUN dnf upgrade -y --releasever=latest
@@ -43,7 +45,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -26,6 +26,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 # Install AWS CLI
@@ -41,7 +43,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -22,16 +22,14 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -47,7 +45,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -15,6 +15,8 @@ RUN dnf install -y tar\
   libxslt-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   git \
   && dnf clean all
 
@@ -34,7 +36,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -35,7 +35,6 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-# Use python3 (3.10 from base image) because aws-lambda-builders requires Python >= 3.10
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -35,6 +35,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
+# Use python3 (3.10 from base image) because aws-lambda-builders requires Python >= 3.10
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -35,6 +35,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
+# Use python3 (3.11 from base image) because aws-lambda-builders requires Python >= 3.10
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -35,7 +35,6 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-# Use python3 (3.11 from base image) because aws-lambda-builders requires Python >= 3.10
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -21,6 +21,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 RUN dnf upgrade -y --releasever=latest
@@ -38,7 +40,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -21,6 +21,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 RUN dnf upgrade -y --releasever=latest
@@ -38,7 +40,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-python314
+++ b/build-image-src/Dockerfile-python314
@@ -21,6 +21,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   && dnf clean all
 
 # Install AWS CLI
@@ -36,7 +38,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -20,6 +20,7 @@ RUN yum groupinstall -y development && \
   zlib1g-dev \
   libmpc-devel \
   python3-devel \
+  amazon-linux-extras \
   && yum clean all
 
 # Install AWS CLI
@@ -34,9 +35,16 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install Python 3.11 for lambda builders venv (aws-lambda-builders requires Python >= 3.10)
+RUN amazon-linux-extras enable python3.11 && \
+  yum clean metadata && \
+  yum install -y python3.11 && \
+  yum clean all
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -20,6 +20,7 @@ RUN yum groupinstall -y development && \
   zlib1g-dev \
   libmpc-devel \
   python3-devel \
+  amazon-linux-extras \
   && yum clean all
 
 # Install AWS CLI
@@ -34,8 +35,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install Python 3.11 for lambda builders venv (aws-lambda-builders requires Python >= 3.10)
+RUN amazon-linux-extras enable python3.11 && \
+  yum clean metadata && \
+  yum install -y python3.11 && \
+  yum clean all
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -21,16 +21,14 @@ RUN yum groupinstall -y development && \
   libyaml-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
+# Install Python 3.11 (aws-lambda-builders requires Python >= 3.10)
 # https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
+RUN amazon-linux-extras enable python3.11 && \
   yum clean metadata && \
-  yum install -y python38 python38-devel && \
+  yum install -y python3.11 python3.11-devel && \
   yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
+  ln -s /usr/bin/python3.11 /usr/bin/python3 && \
+  ln -s /usr/bin/pip3.11 /usr/bin/pip3
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -46,7 +44,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 
 # Prepare virtualenv for lambda builders
 RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \

--- a/build-image-src/Dockerfile-ruby33
+++ b/build-image-src/Dockerfile-ruby33
@@ -21,6 +21,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   libyaml-devel \
   && dnf clean all
 
@@ -39,7 +41,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv

--- a/build-image-src/Dockerfile-ruby34
+++ b/build-image-src/Dockerfile-ruby34
@@ -21,6 +21,8 @@ RUN dnf groupinstall -y development && \
   zlib-devel \
   libmpc-devel \
   python3-devel \
+  python3.11 \
+  python3.11-devel \
   libyaml-devel \
   && dnf clean all
 
@@ -39,7 +41,8 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   rm samcli.zip && rm -rf sam-installation && sam --version
 
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
+# Use python3.11 because aws-lambda-builders requires Python >= 3.10
+RUN python3.11 -m venv --without-pip /usr/local/opt/lambda-builders
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
 # Install lambda builders in a dedicated Python virtualenv


### PR DESCRIPTION
*Description of changes:*
The default `bootstrap.pypa.io/pip/get-pip.py` script no longer supports Python 3.9, which is the default Python runtime on AL2023. This was causing those images to fail to build. The fix makes it so we no longer use Python 3.9 in the runner, instead using 3.11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
