### PR TITLE
feat: use uv to manage python version for lambda builders

### DIFF
--- a/build-image-src/Dockerfile-dotnet10
+++ b/build-image-src/Dockerfile-dotnet10
@@ -41,13 +41,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -55,7 +57,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet10
+++ b/build-image-src/Dockerfile-dotnet10
@@ -44,6 +44,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -20,16 +20,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel  \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -43,13 +33,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -57,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -36,6 +36,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -24,18 +24,7 @@ RUN yum groupinstall -y development && \
   llvm \
   libicu
 
-RUN yum remove -y python3 python3-devel
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -49,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -63,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-dotnet8
+++ b/build-image-src/Dockerfile-dotnet8
@@ -46,6 +46,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-dotnet8
+++ b/build-image-src/Dockerfile-dotnet8
@@ -43,13 +43,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -57,7 +59,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-dotnet9
+++ b/build-image-src/Dockerfile-dotnet9
@@ -46,6 +46,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-dotnet9
+++ b/build-image-src/Dockerfile-dotnet9
@@ -43,13 +43,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -57,7 +59,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Set up .NET root
 

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -59,10 +59,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -36,6 +36,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -20,16 +20,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -43,13 +33,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -57,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -36,6 +36,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -20,16 +20,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -43,13 +33,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -57,7 +49,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -59,10 +59,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-7.3.1-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -63,10 +63,10 @@ ENV JAVA_HOME="/var/lang"
 # Install Java build tools
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-9.2.0-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.14/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
 
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -38,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -52,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -36,13 +36,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -50,7 +52,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Setup Java Home
 

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -61,10 +61,10 @@ ENV JAVA_HOME="/var/lang"
 # Install Java build tools
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-9.2.0-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.14/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -39,6 +39,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -23,16 +23,6 @@ RUN yum groupinstall -y development && \
   amazon-linux-extras \
   java-1.8.0-openjdk-devel
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -46,13 +36,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -60,7 +52,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Setup Java Home
 ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -61,10 +61,10 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz | \
+  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.8.9/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -39,6 +39,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -25,16 +25,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -48,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -62,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs16x
+++ b/build-image-src/Dockerfile-nodejs16x
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -25,16 +25,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -48,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -62,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs18x
+++ b/build-image-src/Dockerfile-nodejs18x
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -42,15 +42,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs20 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -58,7 +58,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs20x
+++ b/build-image-src/Dockerfile-nodejs20x
@@ -45,6 +45,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -42,15 +42,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs22 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -58,7 +58,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-nodejs22x
+++ b/build-image-src/Dockerfile-nodejs22x
@@ -45,6 +45,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -43,6 +43,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-nodejs24x
+++ b/build-image-src/Dockerfile-nodejs24x
@@ -40,15 +40,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
-# Nodejs22 uses a different version (3.1.3) of OpenSSL. This caused an error when Python (installed via dnf) tries to use the ssl module.
-# Temporarily set LD_LIBRARY_PATH to empty for python and pip to pick up the right OpenSSL version
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  LD_LIBRARY_PATH= /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -56,7 +56,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN LD_LIBRARY_PATH= pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -22,16 +22,6 @@ RUN yum groupinstall -y development && \
   libmpc-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -45,13 +35,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -66,7 +58,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -33,13 +33,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -54,7 +56,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -36,6 +36,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -34,13 +34,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -48,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -37,6 +37,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -34,13 +34,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -48,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -37,6 +37,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -37,13 +37,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -51,7 +53,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1 setuptools
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1 setuptools
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -40,6 +40,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -37,13 +37,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -51,7 +53,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1 setuptools
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1 setuptools
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -40,6 +40,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python314
+++ b/build-image-src/Dockerfile-python314
@@ -35,13 +35,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -49,7 +51,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1 setuptools
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1 setuptools
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python314
+++ b/build-image-src/Dockerfile-python314
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -34,13 +34,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -48,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -37,6 +37,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -34,13 +34,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -48,7 +50,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 # Install uv
 RUN pip3 install uv==0.9.22

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -37,6 +37,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -37,6 +37,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-ruby32
+++ b/build-image-src/Dockerfile-ruby32
@@ -21,16 +21,6 @@ RUN yum groupinstall -y development && \
   libyaml-devel \
   amazon-linux-extras
 
-# Install extras so that Python 3.8 is installable
-# https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
-RUN amazon-linux-extras enable python3.8 && \
-  yum clean metadata && \
-  yum install -y python38 python38-devel && \
-  yum clean all && \
-  ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-  ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
-  python3 --version && \
-  pip3 --version
 
 # Install AWS CLI
 ARG AWS_CLI_ARCH
@@ -44,19 +34,21 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/pip/3.8/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 ENV LANG=en_US.UTF-8
 

--- a/build-image-src/Dockerfile-ruby33
+++ b/build-image-src/Dockerfile-ruby33
@@ -38,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -52,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-ruby33
+++ b/build-image-src/Dockerfile-ruby33
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-ruby34
+++ b/build-image-src/Dockerfile-ruby34
@@ -38,13 +38,15 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
   unzip samcli.zip -d sam-installation && ./sam-installation/install && \
   rm samcli.zip && rm -rf sam-installation && sam --version
 
+# Install uv for Python management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH=/root/.local/bin:$PATH
+
 # Prepare virtualenv for lambda builders
-RUN python3 -m venv --without-pip /usr/local/opt/lambda-builders
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-RUN /usr/local/opt/lambda-builders/bin/python3 get-pip.py
+RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
-  /usr/local/opt/lambda-builders/bin/pip3 --no-cache-dir install "aws-lambda-builders==$AWS_LB_VERSION"
+  uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"
 
 ENV PATH=$PATH:/usr/local/opt/lambda-builders/bin
 
@@ -52,7 +54,7 @@ ENV LANG=en_US.UTF-8
 
 # Wheel is required by SAM CLI to build libraries like cryptography. It needs to be installed in the system
 # Python for it to be picked up during `sam build`
-RUN pip3 install wheel==0.45.1
+RUN uv pip install --python /usr/local/opt/lambda-builders wheel==0.45.1
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-ruby34
+++ b/build-image-src/Dockerfile-ruby34
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 # Install uv for Python management
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders


### PR DESCRIPTION
*Description of changes:*
The lambda builders version update to 1.64.0 made it so that Python 3.9 is no longer supported for running it. This is an issue for AL2 and AL2023 images because the system python version is 3.9 (or less on AL2). To fix this, this PR uses `uv` to manage a python installation of 3.11 and use that instead.

This PR also includes a change to update the Maven version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
