### PR TITLE
fix: install pip into lambda-builders venv for provided.al2/al2023

### DIFF
--- a/build-image-src/Dockerfile-java11
+++ b/build-image-src/Dockerfile-java11
@@ -60,10 +60,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
+  curl -L https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.16/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java17
+++ b/build-image-src/Dockerfile-java17
@@ -60,10 +60,10 @@ ENV JAVA_HOME="/var/lang"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-7.3.1-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
+  curl -L https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-7.3.1/bin:/usr/local/maven/apache-maven-3.9.16/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java21
+++ b/build-image-src/Dockerfile-java21
@@ -64,10 +64,10 @@ ENV JAVA_HOME="/var/lang"
 # Install Java build tools
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-9.2.0-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
+  curl -L https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.16/bin:${PATH}"
 
 
 COPY ATTRIBUTION.txt /

--- a/build-image-src/Dockerfile-java25
+++ b/build-image-src/Dockerfile-java25
@@ -62,10 +62,10 @@ ENV JAVA_HOME="/var/lang"
 # Install Java build tools
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-9.2.0-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
+  curl -L https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-9.2.0/bin:/usr/local/maven/apache-maven-3.9.16/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-java8_al2
+++ b/build-image-src/Dockerfile-java8_al2
@@ -62,10 +62,10 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 
 RUN mkdir /usr/local/gradle && curl -L -o gradle.zip https://downloads.gradle.org/distributions/gradle-6.2.2-bin.zip && \
   unzip -d /usr/local/gradle gradle.zip && rm gradle.zip && mkdir /usr/local/maven && \
-  curl -L https://downloads.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz | \
+  curl -L https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz | \
   tar -zx -C /usr/local/maven
 
-ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.15/bin:${PATH}"
+ENV PATH="/usr/local/gradle/gradle-6.2.2/bin:/usr/local/maven/apache-maven-3.9.16/bin:${PATH}"
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-provided_al2
+++ b/build-image-src/Dockerfile-provided_al2
@@ -40,8 +40,10 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
-# Prepare virtualenv for lambda builders
-RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
+# Prepare virtualenv for lambda builders.
+# --seed installs pip/setuptools/wheel into the venv so customer Makefile build hooks
+# that invoke `python3 -m pip ...` continue to work (this venv is on PATH below).
+RUN uv venv --seed --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
   uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"

--- a/build-image-src/Dockerfile-provided_al2023
+++ b/build-image-src/Dockerfile-provided_al2023
@@ -38,8 +38,10 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
-# Prepare virtualenv for lambda builders
-RUN uv venv --python 3.11 /usr/local/opt/lambda-builders
+# Prepare virtualenv for lambda builders.
+# --seed installs pip/setuptools/wheel into the venv so customer Makefile build hooks
+# that invoke `python3 -m pip ...` continue to work (this venv is on PATH below).
+RUN uv venv --seed --python 3.11 /usr/local/opt/lambda-builders
 # Install lambda builders in a dedicated Python virtualenv
 RUN AWS_LB_VERSION=$(curl -sSL https://raw.githubusercontent.com/aws/aws-sam-cli/v$SAM_CLI_VERSION/pyproject.toml | grep aws_lambda_builders | cut -d'=' -f3 | tr -d '",') && \
   uv pip install --python /usr/local/opt/lambda-builders "aws-lambda-builders==$AWS_LB_VERSION"

--- a/tests/test_build_images.py
+++ b/tests/test_build_images.py
@@ -1070,6 +1070,15 @@ class TestBIProvidedAL2(BuildImageBase):
         self.assertTrue(self.check_package_output("go version", "go1."))
         self.assertTrue(self.is_package_present("go"))
 
+    def test_python_pip_available(self):
+        """
+        Customer Makefile build hooks for provided.al2 routinely call
+        `python3 -m pip install ...`. Regression-test that python3 and pip
+        are both reachable inside the image.
+        """
+        self.assertTrue(self.is_package_present("python3"))
+        self.assertTrue(self.check_package_output("python3 -m pip --version", "pip "))
+
 
 @pytest.mark.provided_al2arm64
 class TestBIProvidedAL2ForArm(BuildImageBase):
@@ -1091,6 +1100,15 @@ class TestBIProvidedAL2ForArm(BuildImageBase):
         """
         self.assertTrue(self.check_package_output("go version", "go1."))
         self.assertTrue(self.is_package_present("go"))
+
+    def test_python_pip_available(self):
+        """
+        Customer Makefile build hooks for provided.al2 routinely call
+        `python3 -m pip install ...`. Regression-test that python3 and pip
+        are both reachable inside the image.
+        """
+        self.assertTrue(self.is_package_present("python3"))
+        self.assertTrue(self.check_package_output("python3 -m pip --version", "pip "))
 
 
 @pytest.mark.provided_al2023x86_64
@@ -1116,6 +1134,15 @@ class TestBIProvidedAL2023(AL2023BasedBuildImageBase):
         self.assertTrue(self.check_package_output("go version", "go1."))
         self.assertTrue(self.is_package_present("go"))
 
+    def test_python_pip_available(self):
+        """
+        Customer Makefile build hooks for provided.al2023 routinely call
+        `python3 -m pip install ...`. Regression-test that python3 and pip
+        are both reachable inside the image.
+        """
+        self.assertTrue(self.is_package_present("python3"))
+        self.assertTrue(self.check_package_output("python3 -m pip --version", "pip "))
+
 
 @pytest.mark.provided_al2023arm64
 class TestBIProvidedAL2023ForArm(AL2023BasedBuildImageBase):
@@ -1137,3 +1164,12 @@ class TestBIProvidedAL2023ForArm(AL2023BasedBuildImageBase):
         """
         self.assertTrue(self.check_package_output("go version", "go1."))
         self.assertTrue(self.is_package_present("go"))
+
+    def test_python_pip_available(self):
+        """
+        Customer Makefile build hooks for provided.al2023 routinely call
+        `python3 -m pip install ...`. Regression-test that python3 and pip
+        are both reachable inside the image.
+        """
+        self.assertTrue(self.is_package_present("python3"))
+        self.assertTrue(self.check_package_output("python3 -m pip --version", "pip "))


### PR DESCRIPTION
## Summary

Two unrelated fixes for `develop`-branch CI breakage:

### 1. `provided.al2` / `provided.al2023`: `python3 -m pip` now works
PR #196 swapped `python -m venv` + `get-pip.py` for `uv venv`, which doesn't install pip into the venv. Combined with #196 also dropping the system python3.8 install in `Dockerfile-provided_al2`, the lambda-builders venv at `/usr/local/opt/lambda-builders` is the only `python3` reachable on PATH. So `python3 -m pip ...` now fails with `No module named pip` — breaking customer Makefile build hooks and SAM CLI's own integration tests.

This was caught downstream by the nightly aws-sam-cli integration tests after #196 merged: https://github.com/aws/aws-sam-cli/actions/runs/25952485953 (six failures across `build-x86-container-2`, `build-x86-2`, and `build-arm64`, all in `test_building_Makefile_*provided.al2*`).

**Fix:** pass `--seed` to `uv venv`, which installs pip/setuptools/wheel into the venv. Restores the pre-#196 contract.

**Test:** add `test_python_pip_available` to all four provided.al2/al2023 image test classes (x86_64 + arm64), asserting `python3 -m pip --version` succeeds. Verified locally: this test fails on the broken (pre-fix) image with the original `No module named pip` error, and passes after the fix.

### 2. Java images: pin maven via `archive.apache.org`
Separate latent bug surfaced when CI ran on this branch: `downloads.apache.org` only hosts the *current* Maven release. After Apache promoted Maven 3.9.16, the pinned `3.9.15` URL returned 404 and the curl|tar pipe died with `gzip: stdin: not in gzip format`, breaking all five Java Dockerfiles (java8_al2, java11, java17, java21, java25).

**Fix:** switch the URL to `archive.apache.org/dist/...` which keeps every historical version forever, and bump pin to 3.9.16. Future Maven releases won't break this URL even if we don't bump the pin.

## Test plan
- [ ] CI green on this PR (especially the five java jobs and the two provided jobs)
- [ ] make build-multi-arch RUNTIME=provided_al2 SAM_CLI_VERSION=$LATEST succeeds locally
- [ ] make test RUNTIME=provided_al2 ARCH=x86_64 SAM_CLI_VERSION=$LATEST passes (incl. new test_python_pip_available); same for arm64, provided_al2023
- [ ] Re-run aws/aws-sam-cli nightly integration tests on the rebuilt images and confirm test_building_Makefile_*provided.al2* pass