### PR TITLE
fix: set UV_PYTHON_PREFERENCE to system

### DIFF
--- a/build-image-src/Dockerfile-python310
+++ b/build-image-src/Dockerfile-python310
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python311
+++ b/build-image-src/Dockerfile-python311
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python312
+++ b/build-image-src/Dockerfile-python312
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python313
+++ b/build-image-src/Dockerfile-python313
@@ -41,6 +41,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python314
+++ b/build-image-src/Dockerfile-python314
@@ -39,6 +39,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python38
+++ b/build-image-src/Dockerfile-python38
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders

--- a/build-image-src/Dockerfile-python39
+++ b/build-image-src/Dockerfile-python39
@@ -38,6 +38,7 @@ RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v$SAM_CLI_VERS
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_PYTHON_PREFERENCE=system
 
 # Prepare virtualenv for lambda builders
 RUN uv venv --python 3.11 /usr/local/opt/lambda-builders


### PR DESCRIPTION
*Issue #, if available:*
#198

*Description of changes:*
#196 introduced an issue in the Python images where `uv` was defaulting to its own managed version of Python rather than the system version. This caused issues when a user wanted Python 3.13, for example, but `uv` was defaulting to 3.11, which we use to manage installation of `lambda-builders`.

This PR updates this by setting the environment variable `UV_PYTHON_PREFERENCE=system`, which will allow `uv python find` to return the system version by default. When we use it to create `lambda-builders` in a venv, `uv` will determine if the system version matches 3.11 (only true for `Dockerfile-python311`) and use that, otherwise it will use the managed version.

I tested using the original commands given in the issue, after building the image:
```
~/dev/aws-sam-build-images % finch run --rm -it amazon/aws-sam-cli-build-image-python3.13:arm64 bash

bash-5.2# uv python find
/var/lang/bin/python
bash-5.2# python --version
Python 3.13.12

# Confirming the venv still has the right version
bash-5.2# /usr/local/opt/lambda-builders/bin/python --version
Python 3.11.15
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
