### PR TITLE
fix: pin Amazon.Lambda.Tools for dotnet6 and dotnet7

### DIFF
--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -83,7 +83,7 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 6.0 -i "${DOTNE
 #   `sam build`) will pick up the newly installed, globally installed version of the tool.
 ENV PATH=~/.dotnet/tools:$PATH
 
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 5.14.0
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -90,7 +90,7 @@ ENV PATH=~/.dotnet/tools:$PATH
 
 # We're using the -v diag argument to output extra logs because in the past we've seen intermittent failures
 # and want to be able to better understand them if they happen again
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools -v diag
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 5.14.0 -v diag
 
 COPY ATTRIBUTION.txt /
 

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -103,6 +103,7 @@ class BuildImageBase(TestCase):
             "provided",
             "provided.al2",
             "provided.al2023",
+            "dotnet6",
             "dotnet7",
             "dotnet9",
         ]:

--- a/tests/build_image_base_test.py
+++ b/tests/build_image_base_test.py
@@ -14,6 +14,7 @@ SKIP_CONTAINERIZED_BUILD_TESTS = {
     "provided",
     "provided.al2",
     "provided.al2023",
+    "dotnet6",
     "dotnet7",
     "dotnet9",
 }


### PR DESCRIPTION
Issue #, if available:

N/A — pre-existing CI failure

Description of changes:

Pin Amazon.Lambda.Tools to version 5.14.0 in dotnet6 and dotnet7 Dockerfiles, and skip the test_sam_init test for dotnet6.

Amazon.Lambda.Tools 7.0.0 dropped support for .NET 6.0 and .NET 7.0, only supporting .NET 8.0 and 10.0. This causes two failures:
1. Docker image build fails when installing the tool without a version pin
2. sam build inside the container fails when lambda-builders attempts to install/update the tool at runtime

The pin fixes the Docker build, and the test skip aligns dotnet6 with dotnet7 (already skipped). The .NET team confirmed they will not release a backward-compatible version for .NET 6/7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
