### PR TITLE
fix: correct Amazon.Lambda.Tools pin from 5.14.0 to 6.0.6 

### DIFF
--- a/build-image-src/Dockerfile-dotnet6
+++ b/build-image-src/Dockerfile-dotnet6
@@ -83,7 +83,7 @@ RUN curl -L https://dot.net/v1/dotnet-install.sh | bash -s -- -c 6.0 -i "${DOTNE
 #   `sam build`) will pick up the newly installed, globally installed version of the tool.
 ENV PATH=~/.dotnet/tools:$PATH
 
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 5.14.0
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 6.0.6
 
 COPY ATTRIBUTION.txt /
 

--- a/build-image-src/Dockerfile-dotnet7
+++ b/build-image-src/Dockerfile-dotnet7
@@ -90,7 +90,7 @@ ENV PATH=~/.dotnet/tools:$PATH
 
 # We're using the -v diag argument to output extra logs because in the past we've seen intermittent failures
 # and want to be able to better understand them if they happen again
-RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 5.14.0 -v diag
+RUN dotnet tool install --tool-path "${DOTNET_ROOT}" Amazon.Lambda.Tools --version 6.0.6 -v diag
 
 COPY ATTRIBUTION.txt /
 


### PR DESCRIPTION
…s not exist on NuGet)

Version 5.14.0 was never published; NuGet silently resolved it to 6.0.0 via approximate best match (NU1603 warning). Pin to 6.0.6 (last version supporting net6.0 and net8.0) for deterministic installs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
